### PR TITLE
[#33] Full Screen 컴포넌트 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,5 +34,6 @@ module.exports = {
     'no-multiple-empty-lines': 'error',
     'no-duplicate-imports': 'error',
     'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+    'react/prop-types': 'off',
   },
 };

--- a/src/components/molecules/FullScreen.tsx
+++ b/src/components/molecules/FullScreen.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+interface FullScreenProps {
+  children: React.ReactNode;
+}
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+  background-color: aliceblue;
+`;
+
+const WebViewBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 500px;
+  min-width: 250px;
+  height: 100%;
+  background-color: #ffffff;
+`;
+
+const FullScreen: React.FunctionComponent<FullScreenProps> = ({ children }) => {
+  return (
+    <Container>
+      <WebViewBox>{children}</WebViewBox>
+    </Container>
+  );
+};
+
+export default FullScreen;


### PR DESCRIPTION
Close #33 

### 사진

![image](https://github.com/petqua/frontend/assets/87417773/bf1c77ba-93c8-4115-a498-2f55023f8bbe)

<br/>

### 설명

다른 페이지를 감싸줄 Full Screen 컴포넌트를 만들었습니다.
```tsx
// HomePage.tsx
const HomePage = () => {
  return (
    <FullScreen>
      <div>hi</div>
      <div>hi</div>
      <div>hi</div>
      <div>hi</div>
      <div>hi</div>
      <div>hi</div>
    </FullScreen>
  );
};
```
> 위와 같이 각 페이지에서 최상단 컴포넌트로 넣거나, 그보다 상위 컴포넌트에서 미리 넣어줄 생각입니다.
  물론 헤더랑, footer 등을 고려해서 추후에 결정할 것 같습니다.
<hr/>

### 커밋 리스트

#### ✅ chore: eslint rule 수정

- 타입스크립트가 정적 타입 검사를 제공하므로 불필요한 검사 off

#### ✅ feat: FullScreen 컴포넌트 구현

- 각 페이지를 감싸줄 컴포넌트 구현

<hr/>

### 의논 사항까지는 아니지만 ㅎㅎ
figma에 없는 디자인이라 배경색을 그냥 제가 마음에 드는 걸로 슈욱 넣었는데
aliceblue는 나중에 디자이너와 얘기해서 배경을 넣던, 배경색을 theme에 주입하든지 할 계획이고
white는 일단은 theme에 없길래 그냥 넣었는데 제가 다음에 white 쓸 때 theme에 넣어놓겠습니다.
