### PR TITLE
[#31] 공지 레이아웃 구현

### DIFF
--- a/src/components/molecules/Notification.tsx
+++ b/src/components/molecules/Notification.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { RegularText } from '../atoms';
+import { theme } from '../../styles/theme';
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 3.6rem;
+  background-color: #f7f7f7;
+  cursor: pointer;
+`;
+
+const Notification = () => {
+  return (
+    <Container>
+      <RegularText size={12} color={theme.color.gray.main}>
+        [공지] 펫쿠아 앱 출시 기념 이벤트 진행중 ! 안전운송 사전 신청하러 가기
+      </RegularText>
+    </Container>
+  );
+};
+
+export default Notification;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,3 +1,5 @@
 import ProductListItem from './ProductListItem';
+import FullScreen from './FullScreen';
+import Notification from './Notification';
 
-export { ProductListItem };
+export { ProductListItem, FullScreen, Notification };

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -22,6 +22,7 @@ interface Font {
   regular16: RuleSet<object>;
   regular14: RuleSet<object>;
   regular12: RuleSet<object>;
+  [key: string]: RuleSet<object>;
 }
 
 interface Color {


### PR DESCRIPTION
Close #31 

### 사진

![image](https://github.com/petqua/frontend/assets/87417773/186a6a38-0189-4a5e-bcbb-5715c680f816)

<br/>

### 설명

공지 레이아웃을 구현했습니다.


### 커밋 리스트

#### ✅ feat: 공지 레이아웃 구현

- Notification (분자) 추가