### PR TITLE
[#19] 펫쿠아 강력추천 미리보기 레이아웃 구현

### DIFF
--- a/src/components/atoms/FlexBox.tsx
+++ b/src/components/atoms/FlexBox.tsx
@@ -5,8 +5,17 @@ interface FlexBox {
   justify?: string;
   align?: string;
   style?: any;
+  onClick?: () => void;
 }
-const FlexBox = ({ children, col, gap, justify, align, style }: FlexBox) => {
+const FlexBox = ({
+  children,
+  col,
+  gap,
+  justify,
+  align,
+  style,
+  onClick,
+}: FlexBox) => {
   return (
     <div
       style={{
@@ -18,6 +27,7 @@ const FlexBox = ({ children, col, gap, justify, align, style }: FlexBox) => {
         alignItems: align || 'flex-start',
         ...style,
       }}
+      onClick={onClick}
     >
       {children}
     </div>

--- a/src/components/molecules/PreviewListTitle.tsx
+++ b/src/components/molecules/PreviewListTitle.tsx
@@ -14,7 +14,7 @@ const PreviewListTitle = ({ title, subTitle, path }: PreviewListTitle) => {
     <FlexBox
       justify="space-between"
       align="flex-end"
-      style={{ padding: '0 14px', width: '100%' }}
+      style={{ padding: '0 1.4rem', width: '100%' }}
     >
       <FlexBox col gap="0.6rem">
         <BoldText size={22} color={theme.color.gray.main}>

--- a/src/components/molecules/PreviewListTitle.tsx
+++ b/src/components/molecules/PreviewListTitle.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from 'react-router-dom';
+import { theme } from '../../styles/theme';
+import { BoldText, FlexBox, RegularText } from '../atoms';
+
+interface PreviewListTitle {
+  title: string;
+  subTitle?: string;
+  path: string;
+}
+
+const PreviewListTitle = ({ title, subTitle, path }: PreviewListTitle) => {
+  const navigate = useNavigate();
+  return (
+    <FlexBox
+      justify="space-between"
+      align="flex-end"
+      style={{ padding: '0 14px', width: '100%' }}
+    >
+      <FlexBox col gap="0.6rem">
+        <BoldText size={22} color={theme.color.gray.main}>
+          {title}
+        </BoldText>
+        {subTitle && (
+          <RegularText size={14} color={theme.color.gray[70]}>
+            {subTitle}
+          </RegularText>
+        )}
+      </FlexBox>
+      <FlexBox onClick={() => navigate(path)} style={{ cursor: 'pointer' }}>
+        <RegularText size={14} color={theme.color.gray[50]}>
+          더보기 {'>'}
+        </RegularText>
+      </FlexBox>
+    </FlexBox>
+  );
+};
+
+export default PreviewListTitle;

--- a/src/components/molecules/ProductListItem.tsx
+++ b/src/components/molecules/ProductListItem.tsx
@@ -8,9 +8,7 @@ import {
   FlexBox,
 } from '../atoms';
 
-interface ProductListItem {
-  isMain?: boolean;
-  isSmall?: boolean;
+interface ProductListItemData {
   imgUrl: string;
   store?: string;
   title: string;
@@ -20,35 +18,32 @@ interface ProductListItem {
   like?: number;
   review?: number;
 }
+interface ProductListItem {
+  isMain?: boolean;
+  isSmall?: boolean;
+  data: ProductListItemData;
+}
 
-const ProductListItem = ({
-  isMain,
-  isSmall,
-  imgUrl,
-  store,
-  title,
-  price,
-  discountRate,
-  discountedPrice,
-  like,
-  review,
-}: ProductListItem) => {
+const ProductListItem = ({ isMain, isSmall, data }: ProductListItem) => {
   return (
     <FlexBox
       col={!isMain}
       align={isMain ? 'center' : ''}
-      gap="0.8rem"
-      style={{ width: isMain ? '100%' : isSmall ? '12rem' : '16rem' }}
+      gap={isMain ? '2.4rem' : '0.8rem'}
+      style={{
+        width: isMain ? '100%' : isSmall ? '12rem' : '16rem',
+        padding: isMain ? '0 1.2rem' : '0',
+      }}
     >
       <ProductImg
         size={isMain ? '16.8rem' : isSmall ? '12rem' : '16rem'}
-        src={imgUrl}
+        src={data.imgUrl}
       />
 
       <FlexBox col gap="0.8rem" style={{ width: isMain ? '14rem' : '' }}>
         {!isSmall && (
           <MediumText size={isMain ? 16 : 12} color={theme.color.gray[50]}>
-            {store || 'S아쿠아'}
+            {data.store || 'S아쿠아'}
           </MediumText>
         )}
 
@@ -65,7 +60,7 @@ const ProductListItem = ({
             marginBottom: isMain ? '1.2rem' : '',
           }}
         >
-          {title || '[대용량] 100% 국내산 호랑이 독 닭가슴살 소장'}
+          {data.title || '[대용량] 100% 국내산 호랑이 독 닭가슴살 소장'}
         </MediumText>
 
         <RegularText
@@ -73,15 +68,15 @@ const ProductListItem = ({
           color={theme.color.gray[60]}
           style={{ textDecoration: 'line-through' }}
         >
-          {price || '30,000'}원
+          {data.price || '30,000'}원
         </RegularText>
 
         <FlexBox align="center" gap="0.8rem">
           <RegularText size={16} color={theme.color.tint.red}>
-            {discountRate || 30}%
+            {data.discountRate || 30}%
           </RegularText>
           <BoldText size={16} color={theme.color.gray.main}>
-            {discountedPrice || '21,000'}원
+            {data.discountedPrice || '21,000'}원
           </BoldText>
         </FlexBox>
 
@@ -93,7 +88,7 @@ const ProductListItem = ({
                 style={{ width: '0.8rem', height: '0.8rem' }}
               />
               <LightText size={12} color={theme.color.blue[70]}>
-                {like || 23}
+                {data.like || 23}
               </LightText>
             </FlexBox>
             <FlexBox align="center" gap="0.4rem">
@@ -102,7 +97,7 @@ const ProductListItem = ({
                 style={{ width: '0.8rem', height: '0.8rem' }}
               />
               <LightText size={12} color={theme.color.blue.main}>
-                {review || 23}
+                {data.review || 23}
               </LightText>
             </FlexBox>
           </FlexBox>

--- a/src/components/molecules/ProductListItem.tsx
+++ b/src/components/molecules/ProductListItem.tsx
@@ -18,6 +18,7 @@ interface ProductListItemData {
   like?: number;
   review?: number;
 }
+
 interface ProductListItem {
   isMain?: boolean;
   isSmall?: boolean;

--- a/src/components/molecules/RowScrollContainer.tsx
+++ b/src/components/molecules/RowScrollContainer.tsx
@@ -1,0 +1,36 @@
+import { styled } from 'styled-components';
+
+interface RowScrollContainer {
+  children: React.ReactNode;
+  gap?: string;
+  style?: any;
+}
+
+const RowScrollContainer = ({ children, gap, style }: RowScrollContainer) => {
+  return (
+    <Container
+      style={{
+        gap,
+        ...style,
+      }}
+    >
+      {children}
+    </Container>
+  );
+};
+
+export default RowScrollContainer;
+
+const Container = styled.div`
+  padding: 0 1.2rem;
+  display: flex;
+  width: 100%;
+  overflow-y: hidden;
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -3,5 +3,15 @@ import FullScreen from './FullScreen';
 import CategoryItem from './CategoryItem';
 import Notification from './Notification';
 import Carousel from './Carousel';
+import PreviewListTitle from './PreviewListTitle';
+import RowScrollContainer from './RowScrollContainer';
 
-export { ProductListItem, FullScreen, CategoryItem, Notification, Carousel };
+export {
+  ProductListItem,
+  FullScreen,
+  CategoryItem,
+  Notification,
+  Carousel,
+  PreviewListTitle,
+  RowScrollContainer,
+};

--- a/src/components/organisms/RcmList.tsx
+++ b/src/components/organisms/RcmList.tsx
@@ -1,7 +1,9 @@
 import { FlexBox } from '../atoms';
-import { ProductListItem } from '../molecules';
-import PreviewListTitle from '../molecules/PreviewListTitle';
-import RowScrollContainer from '../molecules/RowScrollContainer';
+import {
+  ProductListItem,
+  PreviewListTitle,
+  RowScrollContainer,
+} from '../molecules';
 
 const RcmList = () => {
   const RCM_LIST = [

--- a/src/components/organisms/RcmList.tsx
+++ b/src/components/organisms/RcmList.tsx
@@ -1,0 +1,86 @@
+import { FlexBox } from '../atoms';
+import { ProductListItem } from '../molecules';
+import PreviewListTitle from '../molecules/PreviewListTitle';
+import RowScrollContainer from '../molecules/RowScrollContainer';
+
+const RcmList = () => {
+  const RCM_LIST = [
+    {
+      imgUrl: '',
+      title: '구피 50마리',
+      price: '30,000',
+      discountRate: '30',
+      discountedPrice: '21,000',
+      like: 23,
+      review: 1,
+    },
+    {
+      imgUrl: '',
+      title: '구피 50마리',
+      price: '30,000',
+      discountRate: '30',
+      discountedPrice: '21,000',
+      like: 23,
+      review: 1,
+    },
+    {
+      imgUrl: '',
+      title: '구피 50마리',
+      price: '30,000',
+      discountRate: '30',
+      discountedPrice: '21,000',
+      like: 23,
+      review: 1,
+    },
+    {
+      imgUrl: '',
+      title: '구피 50마리',
+      price: '30,000',
+      discountRate: '30',
+      discountedPrice: '21,000',
+      like: 23,
+      review: 1,
+    },
+    {
+      imgUrl: '',
+      title: '구피 50마리',
+      price: '30,000',
+      discountRate: '30',
+      discountedPrice: '21,000',
+      like: 23,
+      review: 1,
+    },
+    {
+      imgUrl: '',
+      title: '구피 50마리',
+      price: '30,000',
+      discountRate: '30',
+      discountedPrice: '21,000',
+      like: 23,
+      review: 1,
+    },
+    {
+      imgUrl: '',
+      title: '구피 50마리',
+      price: '30,000',
+      discountRate: '30',
+      discountedPrice: '21,000',
+      like: 23,
+      review: 1,
+    },
+  ];
+
+  return (
+    <FlexBox col gap="2rem" style={{ padding: '2rem 0' }}>
+      <PreviewListTitle title="펫쿠아 강력 추천!" path="/recommend" />
+      <ProductListItem isMain data={RCM_LIST[0]} />
+      <RowScrollContainer gap="1.2rem">
+        {RCM_LIST.filter((el, idx) => idx > 0).map((el, idx) => (
+          <ProductListItem key={idx} isSmall data={el} />
+        ))}
+      </RowScrollContainer>
+    </FlexBox>
+  );
+};
+
+export default RcmList;

--- a/src/components/organisms/RecommendList.tsx
+++ b/src/components/organisms/RecommendList.tsx
@@ -5,7 +5,7 @@ import {
   RowScrollContainer,
 } from '../molecules';
 
-const RcmList = () => {
+const RecommendList = () => {
   const RCM_LIST = [
     {
       imgUrl: '',
@@ -77,12 +77,12 @@ const RcmList = () => {
       <PreviewListTitle title="펫쿠아 강력 추천!" path="/recommend" />
       <ProductListItem isMain data={RCM_LIST[0]} />
       <RowScrollContainer gap="1.2rem">
-        {RCM_LIST.filter((el, idx) => idx > 0).map((el, idx) => (
-          <ProductListItem key={idx} isSmall data={el} />
+        {RCM_LIST.filter((item, idx) => idx > 0).map((item, idx) => (
+          <ProductListItem key={idx} isSmall data={item} />
         ))}
       </RowScrollContainer>
     </FlexBox>
   );
 };
 
-export default RcmList;
+export default RecommendList;

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,3 +1,4 @@
 import CategoryList from './CategoryList';
+import RcmList from './RcmList';
 
-export { CategoryList };
+export { CategoryList, RcmList };

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,4 +1,4 @@
 import CategoryList from './CategoryList';
-import RcmList from './RcmList';
+import RecommendList from './RecommendList';
 
-export { CategoryList, RcmList };
+export { CategoryList, RecommendList };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Carousel, FullScreen, Notification } from '../components/molecules';
-import { CategoryList, RcmList } from '../components/organisms';
+import { CategoryList, RecommendList } from '../components/organisms';
 
 const CAROUSEL_IMAGES = [
   '/images/1.jpg',
@@ -14,8 +14,8 @@ const HomePage = () => {
       <Notification />
       <Carousel carouselList={CAROUSEL_IMAGES} />
       <Notification />
-      {/* <CategoryList /> */}
-      <RcmList />
+      <CategoryList />
+      <RecommendList />
     </FullScreen>
   );
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Carousel, FullScreen, Notification } from '../components/molecules';
-import { CategoryList } from '../components/organisms';
+import { CategoryList, RcmList } from '../components/organisms';
 
 const CAROUSEL_IMAGES = [
   '/images/1.jpg',
@@ -14,7 +14,8 @@ const HomePage = () => {
       <Notification />
       <Carousel carouselList={CAROUSEL_IMAGES} />
       <Notification />
-      <CategoryList />
+      {/* <CategoryList /> */}
+      <RcmList />
     </FullScreen>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,12 +1,13 @@
 import { Outlet } from 'react-router-dom';
 import ProductListItem from '../components/molecules/ProductListItem';
+import RcmList from '../components/organisms/RcmList';
 
 const MainPage = () => {
   return (
     <>
       {/* <Outlet /> */}
-      <div>메인페이지</div>
-      {/* <ProductListItem /> */}
+      {/* <div>메인페이지</div> */}
+      <RcmList />
     </>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,13 +1,13 @@
 import { Outlet } from 'react-router-dom';
 import ProductListItem from '../components/molecules/ProductListItem';
-import RcmList from '../components/organisms/RcmList';
+import RecommendList from '../components/organisms/RecommendList';
 
 const MainPage = () => {
   return (
     <>
       {/* <Outlet /> */}
       {/* <div>메인페이지</div> */}
-      <RcmList />
+      <RecommendList />
     </>
   );
 };


### PR DESCRIPTION
> Close #19 

### 사진
![image](https://github.com/petqua/frontend/assets/123801984/06254a1e-e509-4e91-bfcf-03d170ccdb16)

### 설명
- 정적 데이터 사용
- 스크롤바가 모바일 버전에서는 얇게 나오도록 설정 (이거 아예 없앨랬는데 도저히 안없어짐..)
- 상세화면으로 이동하는 기능은 이후 api 연동시 넣을 예정

### 요청사항
- 화면 디자인에서 카테고리 리스트의 패딩값과 아이템 리스트의 패딩값이 달라서 통일시키는게 좋을것 같음..
- 카테고리 리스트의 크기 설정이 고정값으로 들어가있어서 모바일 화면으로 봤을 때 전체 너비가 깨지더라고요.. gap의 크기를 반응형으로 수정하시면 좋을것 같습니다.