### PR TITLE
[#29] 배너 이미지 api 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.17.19",
         "@tanstack/react-query-devtools": "^5.17.21",
         "axios": "^1.6.5",
+        "dotenv": "^16.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
@@ -19,6 +20,7 @@
         "zustand": "^4.5.0"
       },
       "devDependencies": {
+        "@types/node": "^20.11.9",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@types/styled-components": "^5.1.34",
@@ -489,6 +491,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.9.tgz",
+      "integrity": "sha512-CQXNuMoS/VcoAMISe5pm4JnEd1Br5jildbQEToEMQvutmv+EaQr90ry9raiudgpyDuqFiV9e4rnjSfLNq12M5w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
@@ -1446,6 +1457,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -4529,6 +4551,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.17.19",
     "@tanstack/react-query-devtools": "^5.17.21",
     "axios": "^1.6.5",
+    "dotenv": "^16.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
@@ -21,6 +22,7 @@
     "zustand": "^4.5.0"
   },
   "devDependencies": {
+    "@types/node": "^20.11.9",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@types/styled-components": "^5.1.34",

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 const { DEV } = import.meta.env;
-
-const baseURL = DEV ? '/api' : 'https://bewater-api.com';
+// proxy 설정때문에 이렇게 해야함
+const baseURL = DEV ? '' : 'https://api.petqua.co.kr';
 
 export const client = axios.create({
   baseURL: baseURL,

--- a/src/apis/homeAPI.ts
+++ b/src/apis/homeAPI.ts
@@ -1,0 +1,17 @@
+import { client } from './axiosInstance';
+
+export const getBannersAPI = async () => {
+  try {
+    const res = await client.get('/banners');
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      // 서버 응답이 있는 경우 (오류 상태 코드 처리)
+      console.error('Server Error:', error.response.data);
+    } else {
+      // 서버 응답이 없는 경우 (네트워크 오류 등)
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,3 @@
+import { getBannersAPI } from './homeAPI';
+
+export { getBannersAPI };

--- a/src/components/atoms/Text.tsx
+++ b/src/components/atoms/Text.tsx
@@ -9,13 +9,13 @@ interface TextProps {
 
 interface FontProps {
   theme: DefaultTheme;
-  fontTheme: string;
+  $fontTheme: string;
 }
 
 export const LightText = ({ children, size, color, style }: TextProps) => {
   const fontTheme = `light${size}`;
   return (
-    <Text fontTheme={fontTheme} style={{ ...style, color: color }}>
+    <Text $fontTheme={fontTheme} style={{ ...style, color: color }}>
       {children}
     </Text>
   );
@@ -24,7 +24,7 @@ export const LightText = ({ children, size, color, style }: TextProps) => {
 export const RegularText = ({ children, size, color, style }: TextProps) => {
   const fontTheme = `regular${size}`;
   return (
-    <Text fontTheme={fontTheme} style={{ ...style, color: color }}>
+    <Text $fontTheme={fontTheme} style={{ ...style, color: color }}>
       {children}
     </Text>
   );
@@ -33,7 +33,7 @@ export const RegularText = ({ children, size, color, style }: TextProps) => {
 export const MediumText = ({ children, size, color, style }: TextProps) => {
   const fontTheme = `medium${size}`;
   return (
-    <Text fontTheme={fontTheme} style={{ ...style, color: color }}>
+    <Text $fontTheme={fontTheme} style={{ ...style, color: color }}>
       {children}
     </Text>
   );
@@ -42,13 +42,13 @@ export const MediumText = ({ children, size, color, style }: TextProps) => {
 export const BoldText = ({ children, size, color, style }: TextProps) => {
   const fontTheme = `bold${size}`;
   return (
-    <Text fontTheme={fontTheme} style={{ ...style, color: color }}>
+    <Text $fontTheme={fontTheme} style={{ ...style, color: color }}>
       {children}
     </Text>
   );
 };
 
 const Text = styled.p<FontProps>`
-  ${({ theme, fontTheme }) => theme.font[fontTheme]}
+  ${({ theme, $fontTheme }) => theme.font[$fontTheme]}
   line-height: 1;
 `;

--- a/src/components/molecules/Carousel.tsx
+++ b/src/components/molecules/Carousel.tsx
@@ -32,8 +32,14 @@ const Button = styled.button<Button>`
   z-index: 1;
 `;
 
+interface Banner {
+  id: string;
+  imageUrl: string;
+  linkUrl: string;
+}
+
 interface Carousel {
-  carouselList: Array<string>;
+  carouselList: Array<Banner>;
 }
 
 const Carousel = ({ carouselList }: Carousel) => {
@@ -81,9 +87,9 @@ const Carousel = ({ carouselList }: Carousel) => {
         <IoIosArrowBack size={36} />
       </Button>
       <CarouselBox ref={carouselRef}>
-        {carouselArray.map((src, idx) => (
-          <Img key={idx} src={src} />
-        ))}
+        {carouselArray.map(
+          (val, idx) => val && <Img key={idx} src={val.imageUrl} />,
+        )}
       </CarouselBox>
       <Button onClick={() => handleClick(1)} $isLeft={false}>
         <IoIosArrowForward size={36} />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+
+/*
 const { DEV } = import.meta.env;
 import { worker } from './mocks/browser.ts';
-
 if (DEV) {
   worker.start();
 }
+*/
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,21 +1,37 @@
 import { HttpResponse, http } from 'msw';
 
 const handlers = [
-  http.get('/api/users', () => {
-    return HttpResponse.json([
-      {
-        id: 'abc-123',
-        name: '김가나',
-      },
-      {
-        id: 'def-456',
-        name: '박다라',
-      },
-      {
-        id: 'ghi-789',
-        name: '이마바',
-      },
-    ]);
+  http.get('/api/announcements', () => {
+    return HttpResponse.json({
+      notification:
+        '[공지] 펫쿠아 앱 출시 기념 이벤트 진행중 ! 안전운송 사전 신청하러 가기',
+    });
+  }),
+  http.get('/api/banners', () => {
+    return HttpResponse.json({
+      data: [
+        {
+          id: '1L',
+          imageUrl: '/images/1.jpg',
+          linkUrl: 'https://www.naver.com/',
+        },
+        {
+          id: '2L',
+          imageUrl: '/images/2.jpg',
+          linkUrl: 'https://www.naver.com/',
+        },
+        {
+          id: '3L',
+          imageUrl: '/images/3.jpg',
+          linkUrl: 'https://www.naver.com/',
+        },
+        {
+          id: '4L',
+          imageUrl: '/images/4.jpg',
+          linkUrl: 'https://www.naver.com/',
+        },
+      ],
+    });
   }),
 ];
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,18 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
 import { Carousel, FullScreen, Notification } from '../components/molecules';
 import { CategoryList } from '../components/organisms';
+import { getBannersAPI } from '../apis';
 
-const CAROUSEL_IMAGES = [
-  '/images/1.jpg',
-  '/images/2.jpg',
-  '/images/3.jpg',
-  '/images/4.jpg',
+// 일단 서버에서 내려주는 값이 없어서 이렇게 해놓음.
+const CAROUSEL_MOCK_DATA = [
+  {
+    id: '1L',
+    imageUrl: '/images/1.jpg',
+    linkUrl: 'https://www.naver.com/',
+  },
+  {
+    id: '2L',
+    imageUrl: '/images/2.jpg',
+    linkUrl: 'https://www.naver.com/',
+  },
+  {
+    id: '3L',
+    imageUrl: '/images/3.jpg',
+    linkUrl: 'https://www.naver.com/',
+  },
+  {
+    id: '4L',
+    imageUrl: '/images/4.jpg',
+    linkUrl: 'https://www.naver.com/',
+  },
 ];
 
 const HomePage = () => {
+  const { data: bannersList } = useQuery({
+    queryKey: ['banners'],
+    queryFn: getBannersAPI,
+    staleTime: 60 * 1000,
+  });
+
   return (
     <FullScreen>
       <Notification />
-      <Carousel carouselList={CAROUSEL_IMAGES} />
+      {bannersList && bannersList.length !== 0 ? (
+        <Carousel carouselList={bannersList} />
+      ) : (
+        <Carousel carouselList={CAROUSEL_MOCK_DATA} />
+      )}
       <Notification />
       <CategoryList />
     </FullScreen>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,21 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
-
+import dotenv from 'dotenv';
 // https://vitejs.dev/config/
+
+// .env 파일 로드
+dotenv.config();
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/banners': {
+        target: process.env.VITE_BASE_URL,
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Close #29


<hr>

### 커밋 리스트

#### ✅ fix: Warning 해결

- styled-component props name 수정


#### ✅ feat: cors 해결을 위한 proxy 설정

- /banners로 끝나는 url의 origin을 target으로 수정 (백엔드와 협의후 /api로 수정 예정)
- dev 환경일 때에는 axios의 baseURL ''으로 설정


#### ✅ chore: gitignore 설정 추가

- .env 추가 (VITE_BASE_URL 들어있음)


#### ✅ chore: MSW 사용 잠정적 보류

- proxy 설정과 겹쳐서 잘 안됨
- 생각만큼 편리하지 않음


#### ✅ feat: 배너 이미지 api 연동

- 캐러셀 컴포넌트 props 수정
- 배너 이미지 api 추가
- dotenv 설치


<hr/>

### 의논 사항
캐러셀 스타일에 문제가 있어서 수정할 예정입니다.
그리고 백엔드에서 내려주는 res가 전부 비어있는 데이터라 이것도 좀 건의하려합니다.
baseurl 담는 .env 파일 추가되었습니다. 카톡으로 알려드릴게요. 
(아 생각해보니 axiosInstance에는 적용을 안해놓았네요.. 다음에 할게요)