### PR TITLE
[#30] 공지 내용 api 연동

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
 
-const { DEV } = import.meta.env;
-// proxy 설정때문에 이렇게 해야함
-const baseURL = DEV ? '' : 'https://api.petqua.co.kr';
+const baseURL = 'https://api.petqua.co.kr';
 
 export const client = axios.create({
   baseURL: baseURL,

--- a/src/apis/homeAPI.ts
+++ b/src/apis/homeAPI.ts
@@ -15,3 +15,19 @@ export const getBannersAPI = async () => {
     throw error;
   }
 };
+
+export const getAnnouncementsAPI = async () => {
+  try {
+    const res = await client.get('/announcements');
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      // 서버 응답이 있는 경우 (오류 상태 코드 처리)
+      console.error('Server Error:', error.response.data);
+    } else {
+      // 서버 응답이 없는 경우 (네트워크 오류 등)
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,3 +1,3 @@
-import { getBannersAPI } from './homeAPI';
+import { getAnnouncementsAPI, getBannersAPI } from './homeAPI';
 
-export { getBannersAPI };
+export { getBannersAPI, getAnnouncementsAPI };

--- a/src/components/molecules/Notification.tsx
+++ b/src/components/molecules/Notification.tsx
@@ -11,11 +11,24 @@ const Container = styled.div`
   cursor: pointer;
 `;
 
-const Notification = () => {
+interface annoucement {
+  id: number;
+  title: string;
+  linkUrl: string;
+}
+interface Notification {
+  announcementList: Array<annoucement>;
+}
+
+const MOCK_DATA = '[공지] 펫쿠아 프론트엔드 개발자 구인 중!';
+
+const Notification = ({ announcementList }: Notification) => {
   return (
     <Container>
       <RegularText size={12} color={theme.color.gray.main}>
-        [공지] 펫쿠아 앱 출시 기념 이벤트 진행중 ! 안전운송 사전 신청하러 가기
+        {announcementList && announcementList.length > 0
+          ? announcementList[0].title
+          : MOCK_DATA}
       </RegularText>
     </Container>
   );

--- a/src/components/molecules/Notification.tsx
+++ b/src/components/molecules/Notification.tsx
@@ -11,13 +11,13 @@ const Container = styled.div`
   cursor: pointer;
 `;
 
-interface annoucement {
+interface Annoucement {
   id: number;
   title: string;
   linkUrl: string;
 }
 interface Notification {
-  announcementList: Array<annoucement>;
+  announcementList: Array<Annoucement>;
 }
 
 const MOCK_DATA = '[공지] 펫쿠아 프론트엔드 개발자 구인 중!';

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,28 +1,28 @@
 import { useQuery } from '@tanstack/react-query';
 import { Carousel, FullScreen, Notification } from '../components/molecules';
 import { CategoryList, RecommendList, NewList } from '../components/organisms';
-import { getBannersAPI } from '../apis';
+import { getAnnouncementsAPI, getBannersAPI } from '../apis';
 
 // 일단 서버에서 내려주는 값이 없어서 이렇게 해놓음.
 const CAROUSEL_MOCK_DATA = [
   {
     id: '1L',
-    imageUrl: '/images/1.jpg',
+    imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },
   {
     id: '2L',
-    imageUrl: '/images/2.jpg',
+    imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },
   {
     id: '3L',
-    imageUrl: '/images/3.jpg',
+    imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },
   {
     id: '4L',
-    imageUrl: '/images/4.jpg',
+    imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },
 ];
@@ -34,18 +34,20 @@ const HomePage = () => {
     staleTime: 60 * 1000,
   });
 
+  const { data: announcementList } = useQuery({
+    queryKey: ['announcements'],
+    queryFn: getAnnouncementsAPI,
+    staleTime: 60 * 1000,
+  });
+
   return (
     <FullScreen>
-      <Notification />
       {bannersList && bannersList.length !== 0 ? (
-        <Carousel carouselList={bannersList} />
+        <Carousel carouselList={[bannersList[0]]} />
       ) : (
         <Carousel carouselList={CAROUSEL_MOCK_DATA} />
       )}
-      <Notification />
-      <CategoryList />
-      <RecommendList />
-      <NewList />
+      <Notification announcementList={announcementList} />
     </FullScreen>
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
-import dotenv from 'dotenv';
-// https://vitejs.dev/config/
 
-// .env 파일 로드
-dotenv.config();
+// https://vitejs.dev/config/
 
 export default defineConfig({
   plugins: [react()],
-  server: {
-    proxy: {
-      '/banners': {
-        target: process.env.VITE_BASE_URL,
-        changeOrigin: true,
-        secure: false,
-        ws: true,
-      },
-    },
-  },
 });


### PR DESCRIPTION
Close #30

![image](https://github.com/petqua/frontend/assets/87417773/1b6dab51-ddb7-4ba2-8100-52f3914a22eb)

<hr>

### 커밋 리스트

#### ✅ chore: cors 설정 변경

- proxy 설정 삭제
- 서버에서 allowedOrigins 추가

#### ✅ feat: 공지 내용 api 연동

- 공지 내용 api 추가
- Notification props 추가

<hr/>

### 의논 사항
공지 고정이 아니라 이것도 애니메이션 있는 캐러셀 느낌인 것을 오늘 알았습니다.
일단은 공지가 하나여도 문제 없을 것 같아 고정으로 두었고 Todo리스트에 추가해놓겠습니다.
cors는 서버쪽에서 allowedOrigin 추가해서 vite proxy 설정 제거했습니다.
HomePage에서 승훈님이 만들어놓으신 컴포넌트까지 다 놓으니까 약간 화면에 문제가 있어서 제외해놓았습니다.
일단 컴포넌트 개별 작업 다 한 후에 홈페이지 리팩토링 한 번 하면 좋을 것 같네요.