### PR TITLE
[#50] 검색 페이지 api 연동

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
+const DEV = import.meta.env;
 
-const baseURL = 'https://api.petqua.co.kr';
+const baseURL = DEV ? '/api' : 'https://api.petqua.co.kr';
 
 export const client = axios.create({
   baseURL: baseURL,

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,4 +1,9 @@
 import { getAnnouncementsAPI, getBannersAPI } from './homeAPI';
 import { getProductsAPI } from './productAPI';
-
-export { getBannersAPI, getAnnouncementsAPI, getProductsAPI };
+import { getTrendingKeywordsAPI } from './searchAPI';
+export {
+  getBannersAPI,
+  getAnnouncementsAPI,
+  getProductsAPI,
+  getTrendingKeywordsAPI,
+};

--- a/src/apis/searchAPI.ts
+++ b/src/apis/searchAPI.ts
@@ -1,0 +1,25 @@
+import { client } from './axiosInstance';
+
+export const getTrendingKeywordsAPI = async (
+  keyword: string,
+  limit: number,
+) => {
+  try {
+    const res = await client.get('/products/keywords', {
+      params: {
+        keyword: keyword,
+        limit: limit,
+      },
+    });
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      // 서버 응답이 있는 경우 (오류 상태 코드 처리)
+      console.error('Server Error:', error.response.data);
+    } else {
+      // 서버 응답이 없는 경우 (네트워크 오류 등)
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/components/molecules/TrendingKeywordList.tsx
+++ b/src/components/molecules/TrendingKeywordList.tsx
@@ -27,6 +27,9 @@ const RecommendLi = styled.li`
   padding: 1.2rem 0;
   gap: 2rem;
   cursor: pointer;
+  &:last-child {
+    border-bottom: none;
+  }
 `;
 
 const TrendingKeywordList = ({ data, debouncedQuery }: TrendingKeywordList) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
-import './index.css';
+//import './index.css';
 
-/*
 const { DEV } = import.meta.env;
 import { worker } from './mocks/browser.ts';
 if (DEV) {
   worker.start();
 }
-*/
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,38 +1,10 @@
-import { HttpResponse, http } from 'msw';
+import { mockGetAnnouncementsAPI, mockGetBannersAPI } from './homeController';
+import { mockGetTrendingKeywordsAPI } from './searchController';
 
 const handlers = [
-  http.get('/api/announcements', () => {
-    return HttpResponse.json({
-      notification:
-        '[공지] 펫쿠아 앱 출시 기념 이벤트 진행중 ! 안전운송 사전 신청하러 가기',
-    });
-  }),
-  http.get('/api/banners', () => {
-    return HttpResponse.json({
-      data: [
-        {
-          id: '1L',
-          imageUrl: '/images/1.jpg',
-          linkUrl: 'https://www.naver.com/',
-        },
-        {
-          id: '2L',
-          imageUrl: '/images/2.jpg',
-          linkUrl: 'https://www.naver.com/',
-        },
-        {
-          id: '3L',
-          imageUrl: '/images/3.jpg',
-          linkUrl: 'https://www.naver.com/',
-        },
-        {
-          id: '4L',
-          imageUrl: '/images/4.jpg',
-          linkUrl: 'https://www.naver.com/',
-        },
-      ],
-    });
-  }),
+  mockGetAnnouncementsAPI,
+  mockGetBannersAPI,
+  mockGetTrendingKeywordsAPI,
 ];
 
 export default handlers;

--- a/src/mocks/homeController.ts
+++ b/src/mocks/homeController.ts
@@ -1,0 +1,43 @@
+import { HttpResponse, http } from 'msw';
+
+export const mockGetAnnouncementsAPI = http.get('/api/announcements', () => {
+  const data = [
+    {
+      id: '1L',
+      title: '[공지] 펫쿠아 프론트엔드 개발자 구인 중!',
+      linkUrl: 'linktoA.com',
+    },
+    {
+      id: '2L',
+      title: '안내 사항',
+      linkUrl: 'linktoB.com',
+    },
+  ];
+  return HttpResponse.json(data);
+});
+
+export const mockGetBannersAPI = http.get('/api/banners', () => {
+  const data = [
+    {
+      id: '1L',
+      imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
+      linkUrl: 'https://www.naver.com/',
+    },
+    {
+      id: '2L',
+      imageUrl: '/images/2.jpg',
+      linkUrl: 'https://www.naver.com/',
+    },
+    {
+      id: '3L',
+      imageUrl: '/images/3.jpg',
+      linkUrl: 'https://www.naver.com/',
+    },
+    {
+      id: '4L',
+      imageUrl: '/images/4.jpg',
+      linkUrl: 'https://www.naver.com/',
+    },
+  ];
+  return HttpResponse.json(data);
+});

--- a/src/mocks/searchController.ts
+++ b/src/mocks/searchController.ts
@@ -1,0 +1,16 @@
+import { HttpResponse, http } from 'msw';
+
+export const mockGetTrendingKeywordsAPI = http.get(
+  '/api/products/keywords',
+  () => {
+    const data = [
+      { id: 1, keyword: '상어' },
+      { id: 2, keyword: '상어 어항' },
+      {
+        id: 3,
+        keyword: '아기 상어 뚜루루 뚜루',
+      },
+    ];
+    return HttpResponse.json(data);
+  },
+);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -50,7 +50,7 @@ const HomePage = () => {
     <FullScreen>
       <TopNav alarm search basket logo />
       {bannersList && bannersList.length !== 0 ? (
-        <Carousel carouselList={[bannersList[0]]} />
+        <Carousel carouselList={bannersList} />
       ) : (
         <Carousel carouselList={CAROUSEL_MOCK_DATA} />
       )}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,0 +1,41 @@
+import {
+  BottomNavBar,
+  FullScreen,
+  RecentSearchList,
+  SearchBar,
+  TrendingKeywordList,
+} from '../components/molecules';
+import { useSearchStore } from '../states';
+import { useDebounce } from '../hooks';
+import { getTrendingKeywordsAPI } from '../apis';
+import { useQuery } from '@tanstack/react-query';
+
+const SearchPage = () => {
+  const { searchInput } = useSearchStore();
+
+  const debouncedQuery = useDebounce(searchInput, 300);
+
+  const { data: trendingKeywordsData } = useQuery({
+    queryKey: ['trendingKeywords', debouncedQuery],
+    queryFn: () => getTrendingKeywordsAPI(debouncedQuery, 10),
+    staleTime: 20 * 1000,
+    gcTime: 60 * 1000,
+  });
+
+  return (
+    <FullScreen>
+      <SearchBar />
+      {searchInput ? (
+        <TrendingKeywordList
+          data={trendingKeywordsData}
+          debouncedQuery={debouncedQuery}
+        />
+      ) : (
+        <RecentSearchList />
+      )}
+      <BottomNavBar activeButton="search" />
+    </FullScreen>
+  );
+};
+
+export default SearchPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,7 +1,7 @@
 import Ex1Page from './Ex1Page';
-import Ex2Page from './Ex2Page';
 import MainPage from './MainPage';
 import HomePage from './HomePage';
 import ProductListPage from './ProductListPage';
+import SearchPage from './SearchPage';
 
-export { Ex1Page, Ex2Page, MainPage, HomePage, ProductListPage };
+export { Ex1Page, MainPage, HomePage, ProductListPage, SearchPage };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
-import { HomePage, ProductListPage } from './pages';
+import { HomePage, ProductListPage, SearchPage } from './pages';
 
 export const router = createBrowserRouter([
   {
@@ -10,6 +10,11 @@ export const router = createBrowserRouter([
   {
     path: '/productList',
     element: <ProductListPage />,
+    errorElement: <div>Unknown Error</div>,
+  },
+  {
+    path: '/search',
+    element: <SearchPage />,
     errorElement: <div>Unknown Error</div>,
   },
 ]);


### PR DESCRIPTION
Close #50 

## MSW 재개
vite proxy 설정과 겹쳐서 사용이 조금 애매해서 잠시 사용을 중단하였는데
vite에서 proxy 설정 제외하고 사용하니 괜찮네요.
개발을 하면서 느껴보니 백엔드 api 개발보다 프론트엔드에서 해당 작업을 먼저 진행하는 경우가 많았고
백엔드에서 api를 내려주더라도 크게 의미있는 데이터가 들어있지 않아서 더미 데이터를 넣는 것이 더 낫다고 판단이 됩니다.
개인적으로 느끼기에 정말 괜찮은 경험이라고 생각해서 승훈님도 사용해보시는 걸 권장드립니다.
지금은 단순하게 올바른 정적인 data만 내려주지만
- 지연 시간 설정
- 동적인 응답 생성
- 상태 코드와 헤더 설정

위와 같은 기능을 제공해서 나중에 유닛 테스트와 통합 테스트도 가능해요. 😀

## 사진

#### 추천 검색어
![image](https://github.com/petqua/frontend/assets/87417773/e20f5376-50f4-4b5e-8444-b5d0a89a529d)
> 하단 border 삭제했습니다.

## 커밋 리스트

#### ✅ feat: 검색어 자동완성 controller 구현

- api 디렉토리 구조와 동일하게 controller 디렉토리 구조 설정
- 검색어 자동완성 controller 추가
- 개발 환경에서는 MSW 사용을 위해 baseURL 수정


#### ✅ feat: 검색 페이지 api 연동

- 검색 페이지 추가
- 검색어 디바운싱 설정
- 검색어 자동완성 api 구현


#### ✅ design: 검색어 자동완성 스타일 수정

- 맨 밑에 border 삭제


<hr/>

### Comment
- 최근 검색어 클릭하는 로직 검색 상세 페이지 만들 때에 추가할 계획입니다.
- MSW 사용하실 때 첫 화면 공지, 배너 데이터가 비어있을 수 있는 데 이건 useQuery가 MSW에서 내려주는 값을 받기 전에 잘못된 데이터가 60초간 캐싱이 되어있어서 그렇습니다. 이것때문에 저도 한참 해맸네요. 해결방법은 그냥 야자수 눌러서 announce랑 banner api refetch 누르면 해결됩니다.