### PR TITLE
[#82] 연관상품 api 연동

### DIFF
--- a/src/apis/productAPI.ts
+++ b/src/apis/productAPI.ts
@@ -2,6 +2,7 @@ import {
   GetProductsAPI,
   GetProductsAPIParams,
   GetProductDetailAPI,
+  GetCategoryProductsAPIParams,
 } from '../interfaces/product';
 import { client } from './axiosInstance';
 
@@ -100,6 +101,36 @@ export const getProductDetailAPI = async (
     };
 
     return { mainData, infoData, etcData };
+  } catch (error: any) {
+    if (error.response) {
+      console.error('Server Error:', error.response.data);
+    } else {
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};
+
+export const getCategoryProductsAPI = async ({
+  family,
+  species,
+  deliveryMethod,
+  lastViewedId,
+  limit,
+  sorter,
+}: GetCategoryProductsAPIParams): Promise<GetProductsAPI> => {
+  try {
+    const res = await client.get('/categories/products', {
+      params: {
+        family,
+        species,
+        deliveryMethod,
+        lastViewedId,
+        limit,
+        sorter,
+      },
+    });
+    return res.data;
   } catch (error: any) {
     if (error.response) {
       console.error('Server Error:', error.response.data);

--- a/src/components/molecules/ProductListItem.tsx
+++ b/src/components/molecules/ProductListItem.tsx
@@ -55,18 +55,22 @@ const ProductListItem = ({ isMain, isSmall, data }: ProductListItem) => {
           {data?.name}
         </MediumText>
 
-        <RegularText
-          size={isMain ? 14 : 12}
-          color={theme.color.gray[60]}
-          style={{ textDecoration: 'line-through' }}
-        >
-          {data?.price.toLocaleString()}원
-        </RegularText>
+        {data?.discountRate !== 0 && (
+          <RegularText
+            size={isMain ? 14 : 12}
+            color={theme.color.gray[60]}
+            style={{ textDecoration: 'line-through' }}
+          >
+            {data?.price.toLocaleString()}원
+          </RegularText>
+        )}
 
         <FlexBox align="center" gap="0.8rem">
-          <RegularText size={16} color={theme.color.tint.red}>
-            {data?.discountRate}%
-          </RegularText>
+          {data?.discountRate !== 0 && (
+            <RegularText size={16} color={theme.color.tint.red}>
+              {data?.discountRate}%
+            </RegularText>
+          )}
           <BoldText size={16} color={theme.color.gray.main}>
             {data?.discountPrice.toLocaleString()}원
           </BoldText>

--- a/src/components/organisms/ProductDetailMain.tsx
+++ b/src/components/organisms/ProductDetailMain.tsx
@@ -30,14 +30,17 @@ const ProductDetailMain = ({ data }: ProductDetailMain) => {
           {data?.reviewCount}개 후기
         </RegularText>
       </FlexBox>
+
       <FlexBox col gap="0.6rem" style={{ width: '100%' }}>
-        <RegularText
-          size={16}
-          color={theme.color.gray[50]}
-          style={{ textDecoration: 'line-through' }}
-        >
-          {data?.price.toLocaleString()}원
-        </RegularText>
+        {data?.discountRate !== 0 && (
+          <RegularText
+            size={16}
+            color={theme.color.gray[50]}
+            style={{ textDecoration: 'line-through' }}
+          >
+            {data?.price.toLocaleString()}원
+          </RegularText>
+        )}
         <FlexBox
           justify="space-between"
           align="center"
@@ -46,9 +49,11 @@ const ProductDetailMain = ({ data }: ProductDetailMain) => {
           <BoldText size={24} color={theme.color.gray.main}>
             {data?.discountPrice.toLocaleString()}원
           </BoldText>
-          <BoldText size={20} color={theme.color.tint.red}>
-            {data?.discountRate}%
-          </BoldText>
+          {data?.discountRate !== 0 && (
+            <BoldText size={20} color={theme.color.tint.red}>
+              {data?.discountRate}%
+            </BoldText>
+          )}
         </FlexBox>
       </FlexBox>
       <Line style={{ margin: '1.2rem 0' }} />

--- a/src/interfaces/product.ts
+++ b/src/interfaces/product.ts
@@ -111,3 +111,12 @@ export interface GetProductDetailAPI {
     isWished?: boolean;
   };
 }
+
+export interface GetCategoryProductsAPIParams {
+  family: string;
+  species?: string[];
+  deliveryMethod?: string;
+  lastViewedId?: number;
+  limit: number;
+  sorter?: string;
+}

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -16,7 +16,6 @@ import { getCategoryProductsAPI } from '../apis/productAPI';
 
 const ProductDetailPage = () => {
   const { productId } = useParams();
-  const navigate = useNavigate();
 
   const { data: { mainData, infoData, etcData } = {}, isSuccess } = useQuery({
     queryKey: ['product-detail', productId],

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -12,28 +12,27 @@ import {
 import { getProductDetailAPI } from '../apis';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
+import { getCategoryProductsAPI } from '../apis/productAPI';
 
 const ProductDetailPage = () => {
   const { productId } = useParams();
+  const navigate = useNavigate();
 
-  const exData = {
-    id: 1,
-    name: 'test',
-    category: '구피',
-    price: 10000,
-    storeName: '펫쿠아',
-    discountRate: 10,
-    discountPrice: 9000,
-    wishCount: 2,
-    reviewCount: 1,
-    reviewAverageScore: 4.0,
-    thumbnailUrl: '',
-  };
-
-  const { data: { mainData, infoData, etcData } = {} } = useQuery({
+  const { data: { mainData, infoData, etcData } = {}, isSuccess } = useQuery({
     queryKey: ['product-detail', productId],
     queryFn: () => getProductDetailAPI(parseInt(productId || '-1')),
     staleTime: 60 * 1000,
+  });
+  const { data: relatedData } = useQuery({
+    queryKey: ['related-products', productId],
+    queryFn: () =>
+      getCategoryProductsAPI({
+        family: infoData?.family || '',
+        sorter: 'REVIEW_COUNT_DESC',
+        limit: 12,
+      }),
+    staleTime: 60 * 1000,
+    enabled: isSuccess,
   });
 
   return (
@@ -45,21 +44,19 @@ const ProductDetailPage = () => {
       <ProductDetailContents data={etcData?.descriptionImageUrls} />
 
       {/* 리뷰 */}
+      {/* 추천 상품 */}
       <RowScrollContainer
         row={2}
-        col={5}
+        col={6}
         style={{
           gridRowGap: '2.4rem',
           gridColumnGap: '1.2rem',
           margin: '4rem 0',
         }}
       >
-        <ProductListItem isSmall data={exData} />
-        <ProductListItem isSmall data={exData} />
-        <ProductListItem isSmall data={exData} />
-        <ProductListItem isSmall data={exData} />
-        <ProductListItem isSmall data={exData} />
-        <ProductListItem isSmall data={exData} />
+        {relatedData?.products.map((item) => (
+          <ProductListItem key={item.id} isSmall data={item} />
+        ))}
       </RowScrollContainer>
 
       {/* 교환/환불 */}


### PR DESCRIPTION
> Close #82 

## 사진
![image](https://github.com/petqua/frontend/assets/123801984/61978306-67bb-4a47-b31e-a41b6abe05c8)

## 커밋 리스트

#### ✅ feat: 상세페이지 연관상품 api 연동

- 같은 카테고리에 속하는 상품들 중 "리뷰 많은 순"으로 상위 12개 항목 표시

#### ✅ feat: 할인없을 시 가격만 표시

#### ✅ refactor: 빌드 오류 해결

## Comment

- [feat: 할인없을 시 가격만 표시] 커밋은 사실 이전 pr에 들어갔어야 하는 내용인데 너무 많은 작업량을 쪼개서 커밋하다 보니까 실수로 놓쳤던 내용입니다...ㅠㅠ 다음부턴 조금 더 자세히 확인하도록 하겠습니다..
- 그 상품 리스트 이미지를 보면 border-radius가 적용이 안되어있는데 해당 내용은 상세페이지 캐러셀 제작하면서 해결될 부분이니 크게 신경안쓰셔도 될것 같습니다!
