### PR TITLE
[#90] 모달 리팩토링

### DIFF
--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -6,7 +6,8 @@ import Carousel from './Carousel';
 import PreviewListTitle from './PreviewListTitle';
 import RowScrollContainer from './RowScrollContainer';
 import Filter from './Filter';
-import Modal from './Modal';
+import ListModal from '../organisms/modals/ListModal';
+import ReviewModal from '../organisms/modals/ReviewModal';
 import TopNav from './TopNav';
 import BottomNavBar from './BottomNavBar';
 import SearchBar from './SearchBar';
@@ -26,7 +27,8 @@ export {
   Carousel,
   PreviewListTitle,
   RowScrollContainer,
-  Modal,
+  ListModal,
+  ReviewModal,
   Filter,
   TopNav,
   BottomNavBar,

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -6,7 +6,9 @@ import ProductDetailMain from './ProductDetailMain';
 import ProductDetailInfo from './ProductDetailInfo';
 import ProductDetailContents from './ProductDetailContents';
 import BottomPayBar from './BottomPayBar';
-import DeliveryAddressModal from './DeliveryAddressModal';
+import DeliveryAddressModal from './modals/DeliveryAddressModal';
+import ListModal from './modals/ListModal';
+import ReviewModal from './modals/ReviewModal';
 
 export {
   CategoryList,
@@ -17,5 +19,7 @@ export {
   ProductDetailInfo,
   ProductDetailContents,
   BottomPayBar,
+  ListModal,
+  ReviewModal,
   DeliveryAddressModal,
 };

--- a/src/components/organisms/modals/DeliveryAddressModal.tsx
+++ b/src/components/organisms/modals/DeliveryAddressModal.tsx
@@ -1,94 +1,13 @@
 import { SetStateAction, useEffect, useState } from 'react';
-import styled, { keyframes } from 'styled-components';
-import { BoldText, FlexBox, MediumText } from '../atoms';
-import { theme } from '../../styles/theme';
+import styled from 'styled-components';
+import { FlexBox, MediumText } from '../../atoms';
+import { theme } from '../../../styles/theme';
 import { IoIosArrowBack } from 'react-icons/io';
+import Modal from '../../molecules/Modal';
 
-interface Modal {
+interface DeliveryAddressModal {
   setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
-  title: string;
 }
-
-// 애니메이션 재사용 될 때 style>animation 파일로 따로 분리할게요
-const fadeIn = keyframes`
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-`;
-
-const fadeOut = keyframes`
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-`;
-
-const slideUp = keyframes`
-from {
-    transform: translateY(100%);
-    opacity: 0;
-}
-to {
-    transform: translateY(0);
-    opacity: 1;
-}
-`;
-
-const slideDown = keyframes`
-from {
-    transform: translateY(0);
-    opacity: 1;
-}
-to {
-    transform: translateY(100%);
-    opacity: 0;
-}
-`;
-
-const ModalOverlay = styled.div<{ $visible: boolean }>`
-  width: 100%;
-  height: 100vh;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 100;
-  display: flex;
-  justify-content: center;
-  align-items: flex-end;
-  background-color: rgba(0, 0, 0, 0.6);
-
-  animation: ${({ $visible }) => ($visible ? fadeIn : fadeOut)} 0.3s ease-in-out;
-`;
-
-const Container = styled.div<{ $visible: boolean }>`
-  width: 100%;
-  min-width: 20rem;
-  max-width: 50rem;
-  height: fit-content;
-  padding-top: 1.6rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  z-index: 101;
-  background-color: white;
-  border-top-left-radius: 1.6rem;
-  border-top-right-radius: 1.6rem;
-  gap: 1.6rem;
-  animation: ${({ $visible }) => ($visible ? slideUp : slideDown)} 0.3s
-    ease-in-out;
-`;
-
-const Bar = styled.div`
-  width: 3.2rem;
-  height: 0.4rem;
-  background-color: ${({ theme }) => theme.color.gray[50]};
-  border-radius: 0.2rem;
-`;
 
 const Input = styled.input`
   border: 0.05rem solid ${({ theme }) => theme.color.gray[50]};
@@ -195,8 +114,7 @@ const InputAddressForm = ({ onChangeHandler }: any) => {
   );
 };
 
-// 모달은 꼭 page 단위에서 사용해야함!!
-const DeliveryAddressModal = ({ setIsOpenModal, title }: Modal) => {
+const DeliveryAddressModal = ({ setIsOpenModal }: DeliveryAddressModal) => {
   const [addressInfo, setAddressInfo] = useState({
     name: '',
     receiver: '',
@@ -231,24 +149,13 @@ const DeliveryAddressModal = ({ setIsOpenModal, title }: Modal) => {
   }, []);
 
   return (
-    <ModalOverlay onClick={handleCloseModal} $visible={visible}>
-      <Container onClick={(e) => e.stopPropagation()} $visible={visible}>
-        <Bar />
-        <FlexBox justify="center" align="center" style={{ width: '100%' }}>
-          <IoIosArrowBack
-            size={24}
-            color={theme.color.gray.main}
-            onClick={handleCloseModal}
-            style={{ position: 'absolute', left: '1rem' }}
-          />
-          <BoldText
-            size={18}
-            color={theme.color.gray.main}
-            style={{ padding: '2rem 0' }}
-          >
-            {title}
-          </BoldText>
-        </FlexBox>
+    <Modal
+      title="운송지 추가"
+      visible={visible}
+      handleCloseModal={handleCloseModal}
+      hasInput
+    >
+      <FlexBox col gap="1.6rem" style={{ width: '100%' }}>
         <InputForm
           title="배송지명"
           name="name"
@@ -265,9 +172,9 @@ const DeliveryAddressModal = ({ setIsOpenModal, title }: Modal) => {
           onChangeHandler={handleChange}
         />
         <InputAddressForm onChangeHandler={handleChange} />
-        <ApplyButton>적용하기</ApplyButton>
-      </Container>
-    </ModalOverlay>
+        <ApplyButton onClick={handleCloseModal}>적용하기</ApplyButton>
+      </FlexBox>
+    </Modal>
   );
 };
 

--- a/src/components/organisms/modals/DeliveryAddressModal.tsx
+++ b/src/components/organisms/modals/DeliveryAddressModal.tsx
@@ -2,7 +2,6 @@ import { SetStateAction, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { FlexBox, MediumText } from '../../atoms';
 import { theme } from '../../../styles/theme';
-import { IoIosArrowBack } from 'react-icons/io';
 import Modal from '../../molecules/Modal';
 
 interface DeliveryAddressModal {

--- a/src/components/organisms/modals/ListModal.tsx
+++ b/src/components/organisms/modals/ListModal.tsx
@@ -1,0 +1,72 @@
+import { SetStateAction, useState } from 'react';
+import { RegularText, BoldText, FlexBox } from '../../atoms';
+import { theme } from '../../../styles/theme';
+import { FaCheck } from 'react-icons/fa6';
+import Modal from '../../molecules/Modal';
+
+interface Option {
+  name: string;
+  title: string;
+}
+
+interface ListModal {
+  value: string;
+  setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
+  setValue: React.Dispatch<SetStateAction<string>>;
+  options: Option[];
+  title: string;
+}
+
+const ListModal = ({
+  setIsOpenModal,
+  setValue,
+  value,
+  options,
+  title,
+}: ListModal) => {
+  const [visible, setVisible] = useState(true);
+
+  // 모달 닫을 시 애니메이션 적용하기 위한 딜레이
+  const handleCloseModal = () => {
+    setVisible(false);
+    setTimeout(() => {
+      setIsOpenModal(false);
+    }, 250);
+  };
+
+  return (
+    <Modal title={title} visible={visible} handleCloseModal={handleCloseModal}>
+      <>
+        {options.map((item, idx) => (
+          <FlexBox
+            key={idx}
+            align="center"
+            justify="space-between"
+            style={{ width: '100%', padding: '2.4rem 3.2rem' }}
+            onClick={() => {
+              setValue(item.name);
+              handleCloseModal();
+            }}
+          >
+            {item.name === value ? (
+              <BoldText size={16} color={theme.color.gray.main}>
+                {item.title}
+              </BoldText>
+            ) : (
+              <RegularText size={16} color={theme.color.gray.main}>
+                {item.title}
+              </RegularText>
+            )}
+
+            {item.name === value && (
+              <FaCheck color={theme.color.gray.main} size={18} />
+            )}
+          </FlexBox>
+        ))}
+        <div style={{ height: '2rem' }} />
+      </>
+    </Modal>
+  );
+};
+
+export default ListModal;

--- a/src/components/organisms/modals/ReviewModal.tsx
+++ b/src/components/organisms/modals/ReviewModal.tsx
@@ -1,0 +1,77 @@
+import { SetStateAction, useState } from 'react';
+import { FlexBox, MediumText } from '../../atoms';
+import { theme } from '../../../styles/theme';
+import { BlueButton, StarRating } from '../../molecules';
+import Modal from '../../molecules/Modal';
+
+interface ReviewModal {
+  value: number | undefined;
+  setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
+  setValue: React.Dispatch<SetStateAction<number | undefined>>;
+  options: number[];
+}
+
+const ReviewModal = ({
+  setIsOpenModal,
+  options,
+  value,
+  setValue,
+}: ReviewModal) => {
+  const [visible, setVisible] = useState(true);
+  const [selectedValue, setSelectedValue] = useState(value);
+
+  // 모달 닫을 시 애니메이션 적용하기 위한 딜레이
+  const handleCloseModal = () => {
+    setVisible(false);
+    setTimeout(() => {
+      setIsOpenModal(false);
+    }, 250);
+  };
+
+  return (
+    <Modal title="평점" visible={visible} handleCloseModal={handleCloseModal}>
+      <>
+        {options.map((item, idx) => {
+          const score = 5 - idx;
+          return (
+            <FlexBox
+              key={idx}
+              align="center"
+              justify="space-between"
+              padding="1.6rem"
+              style={{
+                width: '100%',
+                borderBottom: `0.05rem solid ${theme.color.gray[50]}`,
+                backgroundColor:
+                  selectedValue === score
+                    ? theme.color.blue[40]
+                    : 'transparent',
+              }}
+              onClick={() => {
+                selectedValue !== score
+                  ? setSelectedValue(score)
+                  : setSelectedValue(undefined);
+              }}
+            >
+              <StarRating size={22} gap={0.01} score={score} />
+              <MediumText size={14} color={theme.color.gray[70]}>
+                {item.toLocaleString()}
+              </MediumText>
+            </FlexBox>
+          );
+        })}
+        <BlueButton
+          text="적용하기"
+          onClick={() => {
+            setValue(selectedValue);
+            handleCloseModal();
+          }}
+          isMargin
+          style={{ margin: '2.8rem 0 1.4rem 0' }}
+        />
+      </>
+    </Modal>
+  );
+};
+
+export default ReviewModal;

--- a/src/components/organisms/modals/ReviewModal.tsx
+++ b/src/components/organisms/modals/ReviewModal.tsx
@@ -66,7 +66,6 @@ const ReviewModal = ({
             setValue(selectedValue);
             handleCloseModal();
           }}
-          isMargin
           style={{ margin: '2.8rem 0 1.4rem 0' }}
         />
       </>

--- a/src/pages/ProductListPage.tsx
+++ b/src/pages/ProductListPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { FlexBox } from '../components/atoms';
-import { Modal, Filter, TopNav } from '../components/molecules';
-import { ProductList } from '../components/organisms';
+import { Filter, TopNav } from '../components/molecules';
+import { ProductList, ListModal } from '../components/organisms';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
 import { getProductsAPI } from '../apis';
@@ -98,7 +98,7 @@ const ProductListPage = () => {
 
         {/* =================== 모달 =================== */}
         {isOpenSortModal && (
-          <Modal
+          <ListModal
             options={sortOptions}
             title="필터"
             value={sortValue}

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,13 +1,9 @@
 import { useLocation } from 'react-router-dom';
-import {
-  BottomNavBar,
-  Filter,
-  Modal,
-  SearchBar,
-} from '../components/molecules';
+import { BottomNavBar, Filter, SearchBar } from '../components/molecules';
 import { useState } from 'react';
 import { FlexBox } from '../components/atoms';
-import { ProductList } from '../components/organisms';
+
+import { ProductList, ListModal } from '../components/organisms';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getSearchProductsAPI } from '../apis';
 
@@ -75,7 +71,7 @@ const SearchResultPage = () => {
       />
 
       {isOpenModal && (
-        <Modal
+        <ListModal
           options={currentFilter === 'sort' ? sortOptions : transitOptions}
           title="필터"
           value={currentFilter === 'sort' ? sort : transit}


### PR DESCRIPTION
> Close #90 

## 사진
### 필터 모달
![image](https://github.com/petqua/frontend/assets/123801984/b87aa280-8099-4e1f-9be1-5c588b9ce0bb)

### 입력창 모달
![image](https://github.com/petqua/frontend/assets/123801984/7914f265-6c0a-45a0-8072-8a9f529fca36)

## 커밋 리스트

#### ✅ refactor: 모달 컴포넌트 리팩토링

- 최상위 모달 : molecules
- 커스텀 모달 : organisms > modals

#### ✅ feat: 리뷰 평점 모달 제작

#### ✅ refactor: 빌드 오류 수정


## Modal
### 사용방법
1. organisms > modals 에서 본인이 사용하고자 하는 모달 파일을 생성
2. 가장 상위 모달 파일인 Modal 태그를 import 하고 param값 입력
- title : 제목이 있는 경우 넣고 없으면 생략
- visible : 애니메이션 적용한 닫기를 위해 필요한 인자
- handleCloseModal : 애니메이션 적용한 닫기를 위해 필요한 인자
- hasInput : 입력창 모달인 경우 입력
- hasBackBtn : 두번째 플로우의 모달일 경우 추가입력
> 해당 내용 커스텀 파일에서 반드시 입력 후 인자로 넘겨주기
```
  const [visible, setVisible] = useState(true);

  const handleCloseModal = () => {
    setVisible(false);
    setTimeout(() => {
      setIsOpenModal(false);
    }, 250);
  };
```
3. 커스텀 하고자 하는 내용을 Modal 태그내에 작성하기
> 주의: 하단 padding이 Modal에서 입력 안되어있기 때문에 커스텀 모달에서 내용 작성 시에 하단 padding을 고려해서 작성해야함

## Comment
- 사용방법 간단하게 작성해봤는데 아마 코드 보시면은 이해하실거에요! 혹시 질문있으시면은 언제든지 주시면 됩니다 :)
- 그 뒤로가기버튼 관련해서 디자이너님이랑 얘기 나눠봤는데 입력창이 있는 모달일 경우에는 상단 바 없이 cancel 버튼을 반드시 넣어주고 모달에서 두번째 플로우일 경우 뒤로가기 버튼을 넣어줍니다
- 예를 들어서 "배송지 변경"을 누르고 난 뒤에 나타나는 모달에서 "배송지 추가"버튼을 눌러서 나오게 되는 배송지 추가 모달은 두번째 플로우이기 때문에 뒤로가기 버튼을 넣고, 처음부터 화면에 있는 배송지 추가를 눌러서 나오게 되는 배송지 추가 모달은 첫번째 플로우이기 때문에 cancel 버튼만 넣습니다.
