### PR TITLE
[#79] 배송지 form api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.6.5",
         "dotenv": "^16.4.1",
         "react": "^18.2.0",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
         "react-infinite-scroller": "^1.2.6",
@@ -5330,6 +5331,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -10143,6 +10152,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.6.5",
     "dotenv": "^16.4.1",
     "react": "^18.2.0",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
     "react-infinite-scroller": "^1.2.6",

--- a/src/apis/PaymentAPI.ts
+++ b/src/apis/PaymentAPI.ts
@@ -1,0 +1,50 @@
+import { Address } from '../interfaces/payment';
+import { client } from './axiosInstance';
+
+export const getDefaultAddressAPI = async () => {
+  try {
+    const res = await client.get('/shipping-address/default');
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      // 서버 응답이 있는 경우 (오류 상태 코드 처리)
+      console.error('Server Error:', error.response.data);
+    } else {
+      // 서버 응답이 없는 경우 (네트워크 오류 등)
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};
+
+export const postNewAddressAPI = async ({
+  name,
+  receiver,
+  phoneNumber,
+  zipCode,
+  address,
+  detailAddress,
+  isDefaultAddress,
+}: Address) => {
+  try {
+    const res = await client.post('/shipping-address', {
+      name,
+      receiver,
+      phoneNumber,
+      zipCode,
+      address,
+      detailAddress,
+      isDefaultAddress,
+    });
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      // 서버 응답이 있는 경우 (오류 상태 코드 처리)
+      console.error('Server Error:', error.response.data);
+    } else {
+      // 서버 응답이 없는 경우 (네트워크 오류 등)
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -30,7 +30,7 @@ client.interceptors.response.use(
     return response;
   },
   async (error) => {
-    const { setAccessToken, logout } = useAuthStore();
+    const { setAccessToken, logout } = useAuthStore.getState();
     const customStatusCode = error.response.data.code;
     switch (customStatusCode) {
       case 'A01': {
@@ -53,6 +53,26 @@ client.interceptors.response.use(
         break;
       case 'P10':
         console.error('유효하지 않은 검색어', customStatusCode);
+        break;
+      case 'SA02':
+        alert('잘못된 휴대전화 번호입니다.');
+        console.error('잘못된 휴대전화 번호입니다.', customStatusCode);
+        break;
+      case 'SA03':
+        alert('주소가 입력되지 않았습니다.');
+        console.error('주소가 입력되지 않았습니다.', customStatusCode);
+        break;
+      case 'SA04':
+        alert('상세 주소가 입력되지 않았습니다.');
+        console.error('상세 주소가 입력되지 않았습니다.', customStatusCode);
+        break;
+      case 'SA05':
+        alert('배송지 이름이 입력되지 않았습니다.');
+        console.error('배송지 이름이 입력되지 않았습니다.', customStatusCode);
+        break;
+      case 'SA06':
+        alert('받는 사람이 입력되지 않았습니다.');
+        console.error('받는 사람이 입력되지 않았습니다.', customStatusCode);
         break;
       default:
         console.error('알 수 없는 상태 코드: ', customStatusCode);

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -3,9 +3,11 @@ import {
   getOAuthLoginAPI,
   getOAuthRedirectAPI,
 } from './AuthAPI';
+import { getDefaultAddressAPI, postNewAddressAPI } from './PaymentAPI';
 import { getAnnouncementsAPI, getBannersAPI } from './homeAPI';
 import { getProductsAPI, getProductDetailAPI } from './productAPI';
 import { getSearchProductsAPI, getTrendingKeywordsAPI } from './searchAPI';
+
 export {
   getBannersAPI,
   getAnnouncementsAPI,
@@ -16,4 +18,6 @@ export {
   getOAuthLoginAPI,
   getAccessTokenAPI,
   getProductDetailAPI,
+  getDefaultAddressAPI,
+  postNewAddressAPI,
 };

--- a/src/components/molecules/AddressForm.tsx
+++ b/src/components/molecules/AddressForm.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { BoldText, FlexBox, MediumText, RegularText } from '../atoms';
 import { theme } from '../../styles/theme';
-//import { usePaymentStore } from '../../states';
+import { usePaymentStore } from '../../states';
 import { DeliveryRequestDropdown } from '.';
 
 const Container = styled.section`
@@ -29,10 +29,11 @@ const YesAddressBox = styled.div`
   flex-direction: column;
 `;
 
-const withAddressComponent = (Component: any) => {
-  return function WithAddressComponent(props: any) {
-    // const { address } = usePaymentStore();
-    const address = null;
+const withAddressComponent = <T extends AddressFormProps>(
+  Component: React.ComponentType<T>,
+) => {
+  return function WithAddressComponent(props: T) {
+    const { address } = usePaymentStore();
     // 주소 있는 경우
     if (address) {
       return <YesAddressComponent data={address} />;
@@ -60,18 +61,20 @@ const YesAddressComponent = ({ data }: any) => {
   );
 };
 
-const AddressComponent = withAddressComponent(({ setIsModalOpen }: any) => {
-  return (
-    <NoAddressBox onClick={() => setIsModalOpen(true)}>
-      <MediumText size={18} color={theme.color.gray.main}>
-        배송지가 없습니다.
-      </MediumText>
-      <MediumText size={14} color={theme.color.gray[50]}>
-        배송지 입력하기
-      </MediumText>
-    </NoAddressBox>
-  );
-});
+const AddressComponent = withAddressComponent(
+  ({ setIsModalOpen }: AddressFormProps) => {
+    return (
+      <NoAddressBox onClick={() => setIsModalOpen(true)}>
+        <MediumText size={18} color={theme.color.gray.main}>
+          배송지가 없습니다.
+        </MediumText>
+        <MediumText size={14} color={theme.color.gray[50]}>
+          배송지 입력하기
+        </MediumText>
+      </NoAddressBox>
+    );
+  },
+);
 
 interface AddressFormProps {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/interfaces/payment.ts
+++ b/src/interfaces/payment.ts
@@ -1,0 +1,9 @@
+export interface Address {
+  name: string;
+  receiver: string;
+  phoneNumber: string;
+  zipCode: number | undefined;
+  address: string;
+  detailAddress: string;
+  isDefaultAddress: boolean;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
-
 /*
 const { DEV } = import.meta.env;
 import { worker } from './mocks/browser.ts';
@@ -8,5 +7,4 @@ if (DEV) {
   worker.start();
 }
 */
-
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,9 @@
 import { mockGetAnnouncementsAPI, mockGetBannersAPI } from './homeController';
 import {
+  mockGetDefaultAddressAPI,
+  mockPostNewAddressAPI,
+} from './paymentController';
+import {
   mockGetSearchProductsAPI,
   mockGetTrendingKeywordsAPI,
 } from './searchController';
@@ -9,6 +13,8 @@ const handlers = [
   mockGetBannersAPI,
   mockGetTrendingKeywordsAPI,
   mockGetSearchProductsAPI,
+  mockGetDefaultAddressAPI,
+  mockPostNewAddressAPI,
 ];
 
 export default handlers;

--- a/src/mocks/paymentController.ts
+++ b/src/mocks/paymentController.ts
@@ -1,0 +1,34 @@
+import { HttpResponse, http } from 'msw';
+import { Address } from '../interfaces/payment';
+
+export const mockGetDefaultAddressAPI = http.get(
+  '/api/shipping-address/default',
+  () => {
+    const data = {
+      id: 1,
+      name: '집1',
+      receiver: '펫쿠아',
+      phoneNumber: '010-1234-1234',
+      zipCode: 120034,
+      address: '서울시 중앙로 54길 999번지 99',
+      detailAddress: '102호',
+      isDefaultAddress: false,
+    };
+    return HttpResponse.json(data);
+  },
+);
+
+export const mockPostNewAddressAPI = http.post(
+  '/api/shipping-address',
+  async ({ request }) => {
+    const newPost = await request.json();
+    const phoneNumber = (newPost as Address).phoneNumber;
+    if (phoneNumber === '') {
+      return HttpResponse.error();
+    }
+    const data = {
+      id: 1,
+    };
+    return HttpResponse.json(data);
+  },
+);

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { AddressForm, TopNav } from '../components/molecules';
+import { getDefaultAddressAPI } from '../apis';
+import { useEffect, useState } from 'react';
+import { usePaymentStore } from '../states';
+import { DeliveryAddressModal } from '../components/organisms';
+
+const PaymentPage = () => {
+  const { address, setAddress } = usePaymentStore();
+  const { data: defaultAddressData, isLoading } = useQuery({
+    queryKey: ['defaultAddress'],
+    queryFn: getDefaultAddressAPI,
+    staleTime: 30 * 1000,
+    gcTime: 60 * 1000,
+  });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (address !== null) return;
+    if (defaultAddressData) {
+      setAddress(defaultAddressData);
+    }
+  }, [defaultAddressData]);
+
+  return (
+    <>
+      <TopNav backBtn title="주문/결제" />
+      {!isLoading && <AddressForm setIsModalOpen={setIsModalOpen} />}
+      {isModalOpen && (
+        <DeliveryAddressModal
+          title="운송지 추가"
+          setIsOpenModal={setIsModalOpen}
+        />
+      )}
+    </>
+  );
+};
+
+export default PaymentPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -6,6 +6,7 @@ import SearchResultPage from './SearchResultPage';
 import LoginPage from './LoginPage';
 import KakaoLoginPage from './KakaoLoginPage';
 import ProductDetailPage from './ProductDetailPage';
+import PaymentPage from './PaymentPage';
 
 export {
   HomePage,
@@ -16,4 +17,5 @@ export {
   WishListPage,
   LoginPage,
   KakaoLoginPage,
+  PaymentPage,
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import {
   ProductDetailPage,
   LoginPage,
   KakaoLoginPage,
+  PaymentPage,
 } from './pages';
 
 // 인증이 필요한 페이지에 대한 로더 함수
@@ -61,6 +62,12 @@ export const router = createBrowserRouter([
         path: '/auth/login/kakao',
         element: <KakaoLoginPage />,
         errorElement: <div>Unknown Error</div>,
+      },
+      {
+        path: '/payment',
+        element: <PaymentPage />,
+        errorElement: <div>Unknown Error</div>,
+        loader: authorizedLoader,
       },
     ],
   },

--- a/src/states/PaymentStore.ts
+++ b/src/states/PaymentStore.ts
@@ -5,7 +5,7 @@ interface Address {
   name: string;
   receiver: string;
   phoneNumber: string;
-  zipCode: number;
+  zipCode: number | undefined;
   address: string;
   detailAddress: string;
   isDefaultAddress: boolean;


### PR DESCRIPTION
> Close #79 

## Preview
https://frontend-git-79-form-api-blueapple99s-projects.vercel.app/

## access 토큰 interceptors로 관리하기
```jsx
export const client = axios.create({
  baseURL: baseURL,
  timeout: 5000,
  withCredentials: true,
});

client.interceptors.request.use(
  (config) => {
    const token = localStorage.getItem('accessToken');
    if (token) {
      config.headers.Authorization = `Bearer ${token}`;
    }
    return config;
  },
  (error) => {
    return Promise.reject(error);
  },
);

client.interceptors.response.use(
  (response) => {
    return response;
  },
  async (error) => {
    const { setAccessToken, logout } = useAuthStore.getState();
    const customStatusCode = error.response.data.code;
    switch (customStatusCode) {
      case 'A01': {
        const res = await getAccessTokenAPI();
        const newAccessToken = res.headers['authorization'];
        setAccessToken(newAccessToken);
        console.error('로그인 유지 API 적용', customStatusCode);
        break;
      }
      case 'A02':
      case 'A10':
      case 'A11':
      case 'A12':
      case 'A13':
      case 'A20':
      case 'A30':
        logout();
        window.location.href = '/login';
        console.error('소셜 로그인 유도', customStatusCode);
        break;
      default:
        console.error('알 수 없는 상태 코드: ', customStatusCode);
    }
    return Promise.reject(error);
  },
);

```
interceptors를 활용하여 모든 api를 호출할 때 헤더에 accessToken을 넣어주고 있습니다.
또한 인증 관련 커스텀 에러 코드를 서버에서 내려주면 A01인 경우 가지고 있는 refreshToken을 활용하여 다시 accessToken을 요청하고, 그 외에 에러 코드인 경우에는 로그아웃을 시킨 후 다시 로그인을 하게 끔 처리하고 있습니다.

## Zustand 주의할 점
`const { setAccessToken, logout } = useAuthStore.getState();`
interceptors와 같이 컴포넌트가 아닌 곳에서 상태를 조회하거나 업데이트할 때에는 getState()를 통해 상태에 접근해야 한다.
평소와 같이 `const { setAccessToken, logout } = useAuthStore();` 이렇게 접근하면 정상적으로 작동하지 않는다.

## 사진

### 다음 주소 찾기
<img src="https://github.com/petqua/frontend/assets/87417773/07e1eac0-1eb9-40d9-93d9-b58232e22274" width='800' />

### 주소 클릭 후
<img src="https://github.com/petqua/frontend/assets/87417773/16070eba-cea5-4d00-9b2f-ca03e51055f4" width='800'  />

### 결과
![image](https://github.com/petqua/frontend/assets/87417773/86533308-b0fa-4ab8-b938-66f328edc8db)


## 커밋 리스트

#### ✅ feat: 배송지 API controller 구현

- 기본 배송지 조회 controller 추가
- 배송지 추가 controller 추가

#### ✅ feat: 배송지 form api 구현

- 기본 배송지 조회 api 구현
- 배송지 추가 api 구현
- address type 추가
- interceptors에서 배송지 에러 핸들링
- Zustand getState()로 컴포넌트 밖에서 상태 조회 및 업데이트

#### ✅ feat: 주문 결제 페이지 추가

- 간단한 레이아웃 구현
- 배송지 설정 로직 주입

#### ✅ feat: 배송지 입력 modal api 작업

- 다음 주소 찾기 api 연동
- 배송지 추가 api 연동

## Comment

- 이번 작업에 경우 예외 코드를 모두 interceptors에 넣어 놓았는데 인증과 같이 여러 api에서 다발적으로 발생할 수 있는 예외 코드가 아닌 경우에는 interceptors말고 api 내부에서 에러 핸들링을 하는 게 더 나을지 고민입니다. 전자의 경우 모든 예외 코드 처리를 interceptors 내에서 다루기 때문에 관리하기 편하지만 interceptors안에 들어있는 코드의 길이가 길어진다는 단점이 있습니다. 
