### PR TITLE
[#87] 후기 통계조회 api 연동

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -7,6 +7,7 @@ import { getDefaultAddressAPI, postNewAddressAPI } from './PaymentAPI';
 import { getAnnouncementsAPI, getBannersAPI } from './homeAPI';
 import { getProductsAPI, getProductDetailAPI } from './productAPI';
 import { getSearchProductsAPI, getTrendingKeywordsAPI } from './searchAPI';
+import { getReviewStatisticsAPI } from './reviewAPI';
 
 export {
   getBannersAPI,
@@ -18,6 +19,7 @@ export {
   getOAuthLoginAPI,
   getAccessTokenAPI,
   getProductDetailAPI,
+  getReviewStatisticsAPI,
   getDefaultAddressAPI,
   postNewAddressAPI,
 };

--- a/src/apis/reviewAPI.ts
+++ b/src/apis/reviewAPI.ts
@@ -1,0 +1,39 @@
+import { client } from './axiosInstance';
+import { GetReviewStatisticsAPI } from '../interfaces/review';
+
+export const getReviewStatisticsAPI = async (
+  productId: number,
+): Promise<GetReviewStatisticsAPI> => {
+  try {
+    const { data } = await client.get(
+      `/products/${productId}/review-statistics`,
+    );
+    const {
+      averageScore,
+      productSatisfaction,
+      scoreFiveCount,
+      scoreFourCount,
+      scoreOneCount,
+      scoreThreeCount,
+      scoreTwoCount,
+      totalReviewCount,
+    } = data;
+
+    const scoreCounts = [
+      scoreFiveCount,
+      scoreFourCount,
+      scoreThreeCount,
+      scoreTwoCount,
+      scoreOneCount,
+    ];
+
+    return { scoreCounts, averageScore, productSatisfaction, totalReviewCount };
+  } catch (error: any) {
+    if (error.response) {
+      console.error('Server Error:', error.response.data);
+    } else {
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/components/organisms/ReviewOverview.tsx
+++ b/src/components/organisms/ReviewOverview.tsx
@@ -65,7 +65,9 @@ const ReviewOverview = () => {
                 {5 - idx}점
               </MediumText>
               <Bar ref={(el) => el && (barsRef.current[idx] = el)}>
-                <div />
+                <div
+                  style={{ width: `${(item / data?.totalReviewCount) * 100}%` }}
+                />
               </Bar>
               <MediumText size={10} color={theme.color.gray[50]}>
                 {item.toLocaleString()}

--- a/src/components/organisms/ReviewOverview.tsx
+++ b/src/components/organisms/ReviewOverview.tsx
@@ -2,10 +2,14 @@ import { styled } from 'styled-components';
 import { theme } from '../../styles/theme';
 import { FlexBox, BoldText, MediumText, RegularText } from '../atoms';
 import { StarRating } from '../molecules';
-// import { GetReviewStatisticsAPI } from '../../interfaces/review';
+import { GetReviewStatisticsAPI } from '../../interfaces/review';
 import { useRef, useEffect } from 'react';
 
-const ReviewOverview = () => {
+const ReviewOverview = ({
+  data,
+}: {
+  data: GetReviewStatisticsAPI | undefined;
+}) => {
   // bar의 길이를 최소 길이에 맞추는 작업
   const barsRef = useRef<HTMLDivElement[]>([]);
 
@@ -21,7 +25,7 @@ const ReviewOverview = () => {
   return (
     <FlexBox col gap="0.8rem" padding="2.4rem 1.4rem">
       <BoldText size={20} color={theme.color.gray[70]}>
-        후기 100
+        후기 {data?.totalReviewCount}
       </BoldText>
       <FlexBox
         align="center"
@@ -35,11 +39,11 @@ const ReviewOverview = () => {
             color={theme.color.gray.main}
             style={{ marginBottom: '0.8rem' }}
           >
-            3.0
+            {data?.averageScore.toFixed(1)}
           </BoldText>
           <StarRating size={22} gap={0.1} score={5} />
           <RegularText size={14} color={theme.color.gray[50]}>
-            만족도 40%
+            만족도 {data?.productSatisfaction}%
           </RegularText>
         </FlexBox>
         <div
@@ -50,7 +54,7 @@ const ReviewOverview = () => {
           }}
         />
         <FlexBox col gap="0.8rem" style={{ width: '50%' }}>
-          {[10, 200, 500, 4000, 12000].map((item, idx) => (
+          {data?.scoreCounts.map((item, idx) => (
             <FlexBox
               key={idx}
               align="center"
@@ -91,7 +95,6 @@ const Bar = styled.div`
 
   div {
     position: absolute;
-    width: 80%;
     height: 0.6rem;
     border-radius: 0.3rem;
     background-color: ${({ theme }) => theme.color.blue.main};

--- a/src/interfaces/review.ts
+++ b/src/interfaces/review.ts
@@ -1,0 +1,6 @@
+export interface GetReviewStatisticsAPI {
+  scoreCounts: number[];
+  productSatisfaction: number;
+  totalReviewCount: number;
+  averageScore: number;
+}

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -10,7 +10,10 @@ import {
   BottomPayBar,
   ReviewOverview,
 } from '../components/organisms';
-import { getProductDetailAPI } from '../apis';
+import {
+  getProductDetailAPI,
+  getReviewStatisticsAPI,
+} from '../apis';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import { getCategoryProductsAPI } from '../apis/productAPI';
@@ -22,6 +25,12 @@ const ProductDetailPage = () => {
     queryKey: ['product-detail', productId],
     queryFn: () => getProductDetailAPI(parseInt(productId || '-1')),
     staleTime: 60 * 1000,
+  });
+
+  const { data: reviewOverviewData } = useQuery({
+    queryKey: ['review-statistics', productId],
+    queryFn: () => getReviewStatisticsAPI(parseInt(productId || '-1')),
+    staleTime: 30 * 1000,
   });
   const { data: relatedData } = useQuery({
     queryKey: ['related-products', productId],
@@ -44,7 +53,7 @@ const ProductDetailPage = () => {
       <ProductDetailContents data={etcData?.descriptionImageUrls} />
 
       {/* 리뷰 */}
-      <ReviewOverview />
+      <ReviewOverview data={reviewOverviewData} />
       {/* 추천 상품 */}
       <RowScrollContainer
         row={2}

--- a/src/pages/ProductListPage.tsx
+++ b/src/pages/ProductListPage.tsx
@@ -29,7 +29,6 @@ const ProductListPage = () => {
 
   const [searchParams] = useSearchParams();
   const type = searchParams.get('type') || 'exception';
-  // const lastView = searchParams.get('lastView') || '1';
 
   const types: Types = {
     recommend: {
@@ -66,6 +65,7 @@ const ProductListPage = () => {
     initialPageParam: -1,
     getNextPageParam: (lastPage) => {
       const length = lastPage.products.length - 1;
+      if (!lastPage.hasNextPage) return undefined;
       return lastPage.products[length].id;
     },
     staleTime: 60 * 1000,

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -1,0 +1,22 @@
+import { ReviewOverview } from '../components/organisms';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { getReviewStatisticsAPI } from '../apis/reviewAPI';
+
+const ReviewPage = () => {
+  const { productId } = useParams();
+
+  const { data } = useQuery({
+    queryKey: ['review-statistics', productId],
+    queryFn: () => getReviewStatisticsAPI(parseInt(productId || '-1')),
+    staleTime: 30 * 1000,
+  });
+
+  return (
+    <>
+      <ReviewOverview data={data} />
+    </>
+  );
+};
+
+export default ReviewPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -6,6 +6,7 @@ import SearchResultPage from './SearchResultPage';
 import LoginPage from './LoginPage';
 import KakaoLoginPage from './KakaoLoginPage';
 import ProductDetailPage from './ProductDetailPage';
+import ReviewPage from './ReviewPage';
 import PaymentPage from './PaymentPage';
 
 export {
@@ -16,6 +17,7 @@ export {
   SearchResultPage,
   WishListPage,
   LoginPage,
+  ReviewPage,
   KakaoLoginPage,
   PaymentPage,
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,7 @@ import {
   SearchResultPage,
   ProductDetailPage,
   LoginPage,
+  ReviewPage,
   KakaoLoginPage,
   PaymentPage,
 } from './pages';
@@ -35,6 +36,11 @@ export const router = createBrowserRouter([
       {
         path: '/product/:productId',
         element: <ProductDetailPage />,
+        errorElement: <div>Unknown Error</div>,
+      },
+      {
+        path: '/product/:productId/review',
+        element: <ReviewPage />,
         errorElement: <div>Unknown Error</div>,
       },
       {


### PR DESCRIPTION
> Close #87 

## 사진
![image](https://github.com/petqua/frontend/assets/123801984/50d80d50-46bc-4a24-9ecb-4e432c3fc960)


## 커밋 리스트

#### ✅ feat: 전체에서의 비율 만큼 바의 길이 조정

#### ✅ feat: 후기 통계조회 api 연동

#### ✅ refactor: 상품 목록 조회 api 제어

- 다음 페이지 없을 시 api 요청 제어

## Comment

- 후기 통계조회 api를 overview 컴포넌트가 아니라 페이지 컴포넌트에서 요청하는 이유: 후기 더보기 버튼에 후기의 총 개수를 기입하기 위해
![image](https://github.com/petqua/frontend/assets/123801984/f65d6111-c0c9-4595-be93-65d5b1094df1)

- 파란 바의 길이 조정은...ㅎㅎ layout에서 작업해야하는 내용인데 까먹어서 호다닥 끼워넣었습니다