### PR TITLE
[#95] 결제 어종 정보 레이아웃 구현

### DIFF
--- a/src/components/atoms/CustomHr.tsx
+++ b/src/components/atoms/CustomHr.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const Hr = styled.hr<{ $height: string; $color: string }>`
+  height: ${({ $height }) => $height};
+  background-color: ${({ $color }) => $color};
+  border: none;
+`;
+
+interface CustomHr {
+  height: string;
+  color: string;
+}
+
+const CustomHr = ({ height, color }: CustomHr) => {
+  return <Hr $height={height} $color={color} />;
+};
+
+export default CustomHr;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,3 +1,4 @@
+import CustomHr from './CustomHr';
 import FlexBox from './FlexBox';
 import KeywordText from './KeywordText';
 import ProductImg from './ProductImg';
@@ -11,4 +12,5 @@ export {
   MediumText,
   BoldText,
   KeywordText,
+  CustomHr,
 };

--- a/src/components/molecules/CartFish.tsx
+++ b/src/components/molecules/CartFish.tsx
@@ -1,0 +1,83 @@
+import styled from 'styled-components';
+import { CartItemDetails } from '../../interfaces/payment';
+import React from 'react';
+import { FlexBox, MediumText, RegularText } from '../atoms';
+import { theme } from '../../styles/theme';
+
+const Container = styled.div`
+  padding: 1.2rem 0.7rem;
+  display: flex;
+  gap: 1.4rem;
+`;
+
+const ImageBox = styled.div`
+  width: 10rem;
+  height: 10rem;
+  background-color: ${({ theme }) => theme.color.gray[30]};
+  border-radius: 0.5rem;
+  & > img {
+    width: 100%;
+    height: 100%;
+    border-radius: 0.5rem;
+    object-fit: contain;
+  }
+`;
+
+const CartFish = React.memo((props: CartItemDetails) => {
+  const {
+    productThumbnailUrl,
+    storeName,
+    productName,
+    quantity,
+    isMale,
+    isOnSale,
+    productDiscountRate,
+    productDiscountPrice,
+    productPrice,
+  } = props;
+  return (
+    <Container>
+      <ImageBox>
+        <img src={productThumbnailUrl} alt={productName} />
+      </ImageBox>
+      <FlexBox col gap="0.8rem" style={{ flex: 1 }}>
+        <RegularText size={14} color={theme.color.gray[50]}>
+          {storeName}
+        </RegularText>
+        <MediumText size={18} color={theme.color.gray.main}>
+          {productName}
+        </MediumText>
+        <RegularText size={14} color={theme.color.gray[50]}>
+          마릿수 {quantity} | {isMale ? '수컷' : '암컷'}
+        </RegularText>
+        <FlexBox gap="0.8rem" style={{ width: '100%' }}>
+          {isOnSale && (
+            <>
+              <MediumText size={12} color={theme.color.tint.red}>
+                [{productDiscountRate}%]
+              </MediumText>
+              <RegularText
+                size={14}
+                color={isOnSale ? theme.color.gray[50] : theme.color.gray.main}
+                style={{ textDecoration: 'line-through' }}
+              >
+                {productPrice.toLocaleString()} 원
+              </RegularText>
+            </>
+          )}
+          <MediumText
+            size={18}
+            color={theme.color.gray.main}
+            style={{ marginLeft: 'auto' }}
+          >
+            {productDiscountPrice.toLocaleString()} 원
+          </MediumText>
+        </FlexBox>
+      </FlexBox>
+    </Container>
+  );
+});
+
+CartFish.displayName = 'CartFish';
+
+export default CartFish;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -18,6 +18,7 @@ import WhiteButton from './WhiteButton';
 import AddressForm from './AddressForm';
 import DeliveryRequestDropdown from './DeliveryRequestDropdown';
 import StarRating from './StarRating';
+import CartFish from './CartFish';
 
 export {
   ProductListItem,
@@ -40,4 +41,5 @@ export {
   AddressForm,
   DeliveryRequestDropdown,
   StarRating,
+  CartFish,
 };

--- a/src/components/organisms/CartFishList.tsx
+++ b/src/components/organisms/CartFishList.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import { BoldText } from '../atoms';
+import { theme } from '../../styles/theme';
+import { CartFish } from '../molecules';
+import React from 'react';
+import { CartItemDetails } from '../../interfaces/payment';
+
+const Container = styled.div`
+  padding: 2.4rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+interface CartFishListProps {
+  cartData: Array<CartItemDetails>;
+}
+
+const CartFishList = React.memo(({ cartData }: CartFishListProps) => {
+  return (
+    <Container>
+      <BoldText size={18} color={theme.color.gray.main}>
+        어종정보
+      </BoldText>
+      {cartData?.length > 0 &&
+        cartData.map((item) => <CartFish key={item.id} {...item} />)}
+    </Container>
+  );
+});
+
+CartFishList.displayName = 'CartFishList';
+
+export default CartFishList;

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -10,6 +10,7 @@ import ReviewOverview from './ReviewOverview';
 import DeliveryAddressModal from './modals/DeliveryAddressModal';
 import ListModal from './modals/ListModal';
 import ReviewModal from './modals/ReviewModal';
+import CartFishList from './CartFishList';
 
 export {
   CategoryList,
@@ -24,4 +25,5 @@ export {
   ListModal,
   ReviewModal,
   DeliveryAddressModal,
+  CartFishList,
 };

--- a/src/interfaces/payment.ts
+++ b/src/interfaces/payment.ts
@@ -7,3 +7,18 @@ export interface Address {
   detailAddress: string;
   isDefaultAddress: boolean;
 }
+
+export interface CartItemDetails {
+  id: number;
+  storeName: string;
+  productId: number;
+  productName: string;
+  productThumbnailUrl: string;
+  productPrice: number;
+  productDiscountRate: number;
+  productDiscountPrice: number;
+  quantity: number;
+  isMale: boolean;
+  deliveryMethod: string;
+  isOnSale: boolean;
+}

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -3,7 +3,9 @@ import { AddressForm, TopNav } from '../components/molecules';
 import { getDefaultAddressAPI } from '../apis';
 import { useEffect, useState } from 'react';
 import { usePaymentStore } from '../states';
-import { DeliveryAddressModal } from '../components/organisms';
+import { CartFishList, DeliveryAddressModal } from '../components/organisms';
+import { CustomHr } from '../components/atoms';
+import { theme } from '../styles/theme';
 
 const PaymentPage = () => {
   const { address, setAddress } = usePaymentStore();
@@ -23,10 +25,46 @@ const PaymentPage = () => {
     }
   }, [defaultAddressData]);
 
+  const cartData = [
+    {
+      id: 1,
+      storeName: 'S아쿠아',
+      productId: 1,
+      productName: '알비노 풀레드 아시안 고정구피',
+      productThumbnailUrl:
+        'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+      productPrice: 30000,
+      productDiscountRate: 30,
+      productDiscountPrice: 21000,
+      quantity: 1,
+      isMale: true,
+      deliveryMethod: 'SAFETY',
+      isOnSale: true,
+    },
+    {
+      id: 1,
+      storeName: 'N아쿠아',
+      productId: 2,
+      productName: '알빠노 썸블루 아메리칸 유동구피',
+      productThumbnailUrl:
+        'https://docs.petqua.co.kr/products/thumbnails/thumbnail2.jpeg',
+      productPrice: 50000,
+      productDiscountRate: 0,
+      productDiscountPrice: 50000,
+      quantity: 1,
+      isMale: false,
+      deliveryMethod: 'SAFETY',
+      isOnSale: false,
+    },
+  ];
+
   return (
     <>
       <TopNav backBtn title="주문/결제" />
       {!isLoading && <AddressForm setIsModalOpen={setIsModalOpen} />}
+      <CustomHr height="0.8rem" color={theme.color.gray[30]} />
+      <CartFishList cartData={cartData} />
+      <CustomHr height="0.8rem" color={theme.color.gray[30]} />
       {isModalOpen && (
         <DeliveryAddressModal
           title="운송지 추가"

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -41,7 +41,6 @@ export const router = createBrowserRouter([
         path: '/search',
         element: <SearchPage />,
         errorElement: <div>Unknown Error</div>,
-        loader: authorizedLoader,
       },
       {
         path: '/wish',


### PR DESCRIPTION
> Close #95 

## Preview
https://frontend-git-95-blueapple99s-projects.vercel.app/

## 사진
![image](https://github.com/petqua/frontend/assets/87417773/4c64f719-4a10-4341-bc67-8e39285135a0)

## 커밋 리스트

#### ✅ feat: hr 컴포넌트 (atom) 구현

- 높이, 배경 색상 props로 받는 hr 컴포넌트 구현

#### ✅ feat: 결제 어종 정보 레이아웃 구현

- 물품 세부 사항 보여주는 컴포넌트(CartFish) 구현
- 결제 어종 정보 보여주는 컴포넌트(CartFishList) 구현

## Comment

- 화면의 너비를 줄이다 보면 반응형이 필요한 지점들이 있습니다. 나중에 저희 팀원들끼리 테스트 해보면서 반응형에 대해서는 전체적으로 리팩토링하는 시간을 가지면 좋을 것 같습니다.
