### PR TITLE
[#88] 후기 리스트 레이아웃 구현 api 연동

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -5,9 +5,13 @@ import {
 } from './AuthAPI';
 import { getDefaultAddressAPI, postNewAddressAPI } from './PaymentAPI';
 import { getAnnouncementsAPI, getBannersAPI } from './homeAPI';
-import { getProductsAPI, getProductDetailAPI } from './productAPI';
+import {
+  getProductsAPI,
+  getProductDetailAPI,
+  getCategoryProductsAPI,
+} from './productAPI';
 import { getSearchProductsAPI, getTrendingKeywordsAPI } from './searchAPI';
-import { getReviewStatisticsAPI } from './reviewAPI';
+import { getReviewStatisticsAPI, getReviewsAPI } from './reviewAPI';
 
 export {
   getBannersAPI,
@@ -19,7 +23,9 @@ export {
   getOAuthLoginAPI,
   getAccessTokenAPI,
   getProductDetailAPI,
+  getReviewsAPI,
   getReviewStatisticsAPI,
   getDefaultAddressAPI,
   postNewAddressAPI,
+  getCategoryProductsAPI,
 };

--- a/src/apis/reviewAPI.ts
+++ b/src/apis/reviewAPI.ts
@@ -1,5 +1,38 @@
 import { client } from './axiosInstance';
-import { GetReviewStatisticsAPI } from '../interfaces/review';
+import {
+  GetReviewsAPIParams,
+  GetReviewsAPI,
+  GetReviewStatisticsAPI,
+} from '../interfaces/review';
+
+export const getReviewsAPI = async ({
+  productId,
+  lastViewedId,
+  limit,
+  sorter,
+  score,
+  photoOnly,
+}: GetReviewsAPIParams): Promise<GetReviewsAPI> => {
+  try {
+    const res = await client.get(`/products/${productId}/reviews`, {
+      params: {
+        lastViewedId,
+        limit,
+        sorter,
+        score,
+        photoOnly,
+      },
+    });
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      console.error('Server Error:', error.response.data);
+    } else {
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};
 
 export const getReviewStatisticsAPI = async (
   productId: number,

--- a/src/components/atoms/ProfileImg.tsx
+++ b/src/components/atoms/ProfileImg.tsx
@@ -1,0 +1,29 @@
+import { styled } from 'styled-components';
+
+interface ProfileImg {
+  size: number;
+  url: string;
+}
+
+const ProfileImg = ({ size, url }: ProfileImg) => {
+  return (
+    <ImgContainer style={{ width: `${size}rem` }}>
+      {url && <Image src={url} alt="profile-img" />}
+    </ImgContainer>
+  );
+};
+
+export default ProfileImg;
+
+const ImgContainer = styled.div`
+  background-color: ${({ theme }) => theme.color.gray[30]};
+  aspect-ratio: 1;
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,6 +1,7 @@
 import FlexBox from './FlexBox';
 import KeywordText from './KeywordText';
 import ProductImg from './ProductImg';
+import ProfileImg from './ProfileImg';
 import { LightText, RegularText, MediumText, BoldText } from './Text';
 
 export {
@@ -11,4 +12,5 @@ export {
   MediumText,
   BoldText,
   KeywordText,
+  ProfileImg,
 };

--- a/src/components/molecules/BlueButton.tsx
+++ b/src/components/molecules/BlueButton.tsx
@@ -5,13 +5,28 @@ import { theme } from '../../styles/theme';
 interface BlueButton {
   text: string;
   onClick: () => void;
+  isBigText?: boolean;
+  isMargin?: boolean;
   style?: any;
 }
 
-const BlueButton = ({ text, onClick, style }: BlueButton) => {
+const BlueButton = ({
+  text,
+  onClick,
+  isBigText,
+  isMargin,
+  style,
+}: BlueButton) => {
   return (
-    <Button onClick={onClick} style={{ ...style }}>
-      <MediumText size={20} color={theme.color.tint.white}>
+    <Button
+      onClick={onClick}
+      style={{
+        width: isMargin ? 'calc(100% - 2.8rem)' : '100%',
+        margin: isMargin ? '0 1.4rem' : '0',
+        ...style,
+      }}
+    >
+      <MediumText size={isBigText ? 20 : 16} color={theme.color.tint.white}>
         {text}
       </MediumText>
     </Button>
@@ -22,7 +37,6 @@ export default BlueButton;
 
 const Button = styled.button`
   padding: 1.4rem;
-  width: 100%;
   background-color: ${({ theme }) => theme.color.blue[80]};
   border-radius: 0.8rem;
 `;

--- a/src/components/molecules/Filter.tsx
+++ b/src/components/molecules/Filter.tsx
@@ -4,14 +4,21 @@ import { theme } from '../../styles/theme';
 import styled from 'styled-components';
 import { MediumText } from '../atoms';
 import { formatFilter } from '../../utils/format';
+import { IoOptionsOutline } from 'react-icons/io5';
 
 interface Filter {
   value: string;
   setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
   handleFilterClick?: () => void;
+  hasIcon?: boolean;
 }
 
-const Filter = ({ value, setIsOpenModal, handleFilterClick }: Filter) => {
+const Filter = ({
+  value,
+  setIsOpenModal,
+  handleFilterClick,
+  hasIcon,
+}: Filter) => {
   return (
     <Container
       onClick={() => {
@@ -19,10 +26,11 @@ const Filter = ({ value, setIsOpenModal, handleFilterClick }: Filter) => {
         setIsOpenModal((prev) => !prev);
       }}
     >
-      <MediumText size={14} color={theme.color.gray[70]}>
+      {hasIcon && <IoOptionsOutline size={18} color={theme.color.gray[50]} />}
+      <MediumText size={14} color={theme.color.gray[50]}>
         {formatFilter(value)}
       </MediumText>
-      <FaAngleDown color={theme.color.gray[50]} size={12} />
+      {!hasIcon && <FaAngleDown color={theme.color.gray[50]} size={12} />}
     </Container>
   );
 };

--- a/src/components/molecules/ReviewItem.tsx
+++ b/src/components/molecules/ReviewItem.tsx
@@ -1,0 +1,103 @@
+import { styled } from 'styled-components';
+import { RowScrollContainer, StarRating } from '.';
+import { theme } from '../../styles/theme';
+import {
+  BoldText,
+  FlexBox,
+  ProductImg,
+  ProfileImg,
+  RegularText,
+} from '../atoms';
+import { FaRegThumbsUp, FaThumbsUp } from 'react-icons/fa6';
+import { ReviewItem } from '../../interfaces/review';
+import { formatDate } from '../../utils/format';
+
+const ReviewItem = ({ data, isRecommend, isLastItem }: ReviewItem) => {
+  return (
+    <>
+      <FlexBox col padding="2.4rem 0" gap="1.6rem" style={{ width: '100%' }}>
+        <FlexBox
+          align="center"
+          gap="1.6rem"
+          padding="0 1.4rem"
+          style={{ width: '100%' }}
+        >
+          <ProfileImg size={4.4} url={data?.reviewerProfileImageUrl} />
+          <FlexBox justify="space-between" style={{ flex: '1' }}>
+            <FlexBox col gap="0.4rem">
+              <FlexBox gap="0.8rem" align="center">
+                <BoldText size={16} color={theme.color.gray[70]}>
+                  {data?.reviewerName}
+                </BoldText>
+                <StarRating size={10} gap={0.1} score={data?.score} />
+              </FlexBox>
+              <RegularText size={12} color={theme.color.gray[50]}>
+                수조 {data?.reviewerFishBowlCount}개 | 구피 양육{' '}
+                {data?.reviewerYears}년차
+              </RegularText>
+            </FlexBox>
+            <RegularText size={14} color={theme.color.gray[50]}>
+              {formatDate(data?.createdAt)}
+            </RegularText>
+          </FlexBox>
+        </FlexBox>
+
+        {data?.images.length !== 0 && (
+          <RowScrollContainer gap="0.8rem" row={1} col={5}>
+            {data?.images.map((item, idx) => (
+              <ProductImg key={idx} size="12rem" isRound src={item} />
+            ))}
+          </RowScrollContainer>
+        )}
+
+        <RegularText
+          size={14}
+          color={theme.color.gray[70]}
+          style={{ lineHeight: '150%', padding: '0 1.4rem' }}
+        >
+          {data?.content}
+        </RegularText>
+
+        {isRecommend && (
+          <RecommendBtn>
+            {data?.recommended ? (
+              <FaThumbsUp size={16} color={theme.color.blue.main} />
+            ) : (
+              <FaRegThumbsUp size={16} color={theme.color.gray[50]} />
+            )}
+            <RegularText
+              size={14}
+              color={
+                data?.recommended ? theme.color.gray.main : theme.color.gray[50]
+              }
+            >
+              추천 {data?.recommendCount}
+            </RegularText>
+          </RecommendBtn>
+        )}
+      </FlexBox>
+      {!isLastItem && <Line />}
+    </>
+  );
+};
+
+export default ReviewItem;
+
+const RecommendBtn = styled.button`
+  width: 48%;
+  padding: 1rem;
+  margin: 0 1.4rem;
+  border: 0.05rem solid ${({ theme }) => theme.color.gray[50]};
+  border-radius: 0.4rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.8rem;
+`;
+
+const Line = styled.div`
+  width: calc(100% - 2.8rem);
+  height: 0.05rem;
+  margin: 0 1.4rem;
+  background-color: ${({ theme }) => theme.color.gray[50]};
+`;

--- a/src/components/molecules/WhiteButton.tsx
+++ b/src/components/molecules/WhiteButton.tsx
@@ -13,11 +13,15 @@ interface WhiteButton {
 const WhiteButton = ({ text, onClick, style, isDown }: WhiteButton) => {
   return (
     <Button onClick={onClick} style={{ ...style }}>
-      <MediumText size={16} color={theme.color.blue.main}>
+      <MediumText
+        size={16}
+        color={theme.color.blue[70]}
+        style={{ whiteSpace: 'pre-wrap' }}
+      >
         {text}
       </MediumText>
       {/* 사용되는 다른 상황에 따라 유연하게 수정 */}
-      {isDown && <FaChevronDown size={12} color={theme.color.blue.main} />}
+      {isDown && <FaChevronDown size={12} color={theme.color.blue[70]} />}
     </Button>
   );
 };
@@ -32,5 +36,5 @@ const Button = styled.button`
   width: 100%;
   background-color: ${({ theme }) => theme.color.tint.white};
   padding: 1.4rem;
-  border: 1px solid ${({ theme }) => theme.color.blue.main};
+  border: 1px solid ${({ theme }) => theme.color.blue[70]};
 `;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -18,6 +18,7 @@ import WhiteButton from './WhiteButton';
 import AddressForm from './AddressForm';
 import DeliveryRequestDropdown from './DeliveryRequestDropdown';
 import StarRating from './StarRating';
+import ReviewItem from './ReviewItem';
 
 export {
   ProductListItem,
@@ -40,4 +41,5 @@ export {
   AddressForm,
   DeliveryRequestDropdown,
   StarRating,
+  ReviewItem,
 };

--- a/src/components/organisms/ReviewList.tsx
+++ b/src/components/organisms/ReviewList.tsx
@@ -1,0 +1,175 @@
+import styled from 'styled-components';
+import { Filter, ReviewItem } from '../molecules';
+import { FlexBox, BoldText } from '../atoms';
+import { theme } from '../../styles/theme';
+import { SetStateAction, useEffect, useState } from 'react';
+import InfiniteScroll from 'react-infinite-scroller';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getReviewsAPI } from '../../apis';
+import { useParams } from 'react-router-dom';
+import { FaCheck } from 'react-icons/fa6';
+
+interface ReviewList {
+  score: number | undefined;
+  setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
+}
+
+const ReviewList = ({ score, setIsOpenModal }: ReviewList) => {
+  const { productId } = useParams();
+  const [photoOnly, setPhotoOnly] = useState(false);
+  const [sorter, setSorter] = useState<undefined | string>(undefined);
+
+  const { data, fetchNextPage, hasNextPage, refetch } = useInfiniteQuery({
+    queryKey: ['reviews-detail', productId],
+    queryFn: ({ pageParam: lastViewedId }) =>
+      getReviewsAPI({
+        productId: parseInt(productId || '-1'),
+        limit: 20,
+        lastViewedId,
+        sorter,
+        score,
+        photoOnly,
+      }),
+    initialPageParam: -1,
+    getNextPageParam: (lastPage) => {
+      const length = lastPage.productReviews.length - 1;
+      if (!lastPage.hasNextPage) return undefined;
+      return lastPage.productReviews[length].id;
+    },
+    staleTime: 60 * 1000,
+  });
+
+  const handleSorter = (type: string) => {
+    if (sorter === type) {
+      setSorter(undefined);
+    } else {
+      setSorter(type);
+    }
+  };
+
+  useEffect(() => {
+    refetch();
+  }, [photoOnly, sorter, score]);
+
+  return (
+    <>
+      <FilterContainer>
+        <FlexBox align="center" gap="1.2rem">
+          <CheckBox checked={photoOnly}>
+            <input
+              type="checkbox"
+              checked={photoOnly}
+              onChange={(e) => setPhotoOnly(e.currentTarget.checked)}
+            />
+            <div>
+              <FaCheck
+                size={12}
+                color={theme.color.tint.white}
+                style={{
+                  visibility: photoOnly ? 'visible' : 'hidden',
+                }}
+              />
+            </div>
+            <BoldText
+              size={12}
+              color={photoOnly ? theme.color.gray.main : theme.color.gray[50]}
+            >
+              사진/영상
+            </BoldText>
+          </CheckBox>
+          <Line />
+          <BoldText
+            size={12}
+            color={
+              sorter === 'RECOMMEND_DESC'
+                ? theme.color.gray.main
+                : theme.color.gray[50]
+            }
+            style={{ cursor: 'pointer' }}
+            onClick={() => handleSorter('RECOMMEND_DESC')}
+          >
+            추천순
+          </BoldText>
+          <Line />
+          <BoldText
+            size={12}
+            color={
+              sorter === 'REVIEW_DATE_DESC'
+                ? theme.color.gray.main
+                : theme.color.gray[50]
+            }
+            style={{ cursor: 'pointer' }}
+            onClick={() => handleSorter('REVIEW_DATE_DESC')}
+          >
+            최신순
+          </BoldText>
+        </FlexBox>
+        <Filter value="필터" setIsOpenModal={setIsOpenModal} hasIcon />
+      </FilterContainer>
+      <InfiniteScroll loadMore={() => fetchNextPage()} hasMore={hasNextPage}>
+        {data?.pages?.map((items, firstIdx) => {
+          return items?.productReviews.map((item, secondIdx) => (
+            <ReviewItem
+              key={item.id}
+              data={item}
+              isLastItem={
+                data?.pages.length === firstIdx + 1 &&
+                items?.productReviews.length === secondIdx + 1
+              }
+              isRecommend
+            />
+          ));
+        }) || <></>}
+      </InfiniteScroll>
+    </>
+  );
+};
+
+export default ReviewList;
+
+const FilterContainer = styled.div`
+  padding: 1.2rem 0;
+  margin: 0 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 0.05rem solid ${({ theme }) => theme.color.gray[50]};
+  border-bottom: 0.05rem solid ${({ theme }) => theme.color.gray[50]};
+`;
+
+const Line = styled.div`
+  width: 0.1rem;
+  height: 1rem;
+  background-color: ${({ theme }) => theme.color.gray[50]};
+`;
+
+const CheckBox = styled.label<{ checked: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  cursor: pointer;
+
+  input {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 1.8rem;
+    height: 1.8rem;
+    border: ${({ checked, theme }) =>
+      checked ? 'none' : `solid 0.1rem ${theme.color.gray[50]}`};
+    background: ${({ checked, theme }) =>
+      checked ? theme.color.blue[80] : 'white'};
+  }
+`;

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -7,6 +7,7 @@ import ProductDetailInfo from './ProductDetailInfo';
 import ProductDetailContents from './ProductDetailContents';
 import BottomPayBar from './BottomPayBar';
 import ReviewOverview from './ReviewOverview';
+import ReviewList from './ReviewList';
 import DeliveryAddressModal from './modals/DeliveryAddressModal';
 import ListModal from './modals/ListModal';
 import ReviewModal from './modals/ReviewModal';
@@ -21,6 +22,7 @@ export {
   ProductDetailContents,
   BottomPayBar,
   ReviewOverview,
+  ReviewList,
   ListModal,
   ReviewModal,
   DeliveryAddressModal,

--- a/src/components/organisms/modals/ReviewModal.tsx
+++ b/src/components/organisms/modals/ReviewModal.tsx
@@ -66,6 +66,7 @@ const ReviewModal = ({
             setValue(selectedValue);
             handleCloseModal();
           }}
+          isMargin
           style={{ margin: '2.8rem 0 1.4rem 0' }}
         />
       </>

--- a/src/interfaces/review.ts
+++ b/src/interfaces/review.ts
@@ -1,8 +1,39 @@
+export interface GetReviewsAPIParams {
+  productId: number;
+  lastViewedId?: number;
+  limit: number;
+  sorter?: string;
+  score?: number;
+  photoOnly?: boolean;
+}
+
+export interface GetReviewsAPI {
+  productReviews: ReviewItemData[];
+  hasNextPage: boolean;
+}
+
 export interface GetReviewStatisticsAPI {
   scoreCounts: number[];
   productSatisfaction: number;
   totalReviewCount: number;
   averageScore: number;
+}
+
+export interface ReviewItemData {
+  id: number;
+  productId: number;
+  score: number;
+  content: string;
+  recommendCount: number;
+  hasPhotos: true;
+  createdAt: string;
+  reviewerId: number;
+  reviewerName: string;
+  reviewerProfileImageUrl: string;
+  reviewerFishBowlCount: number;
+  reviewerYears: number;
+  recommended: boolean;
+  images: string[];
 }
 
 export interface ReviewItem {

--- a/src/interfaces/review.ts
+++ b/src/interfaces/review.ts
@@ -4,3 +4,9 @@ export interface GetReviewStatisticsAPI {
   totalReviewCount: number;
   averageScore: number;
 }
+
+export interface ReviewItem {
+  data: ReviewItemData;
+  isRecommend?: boolean;
+  isLastItem?: boolean;
+}

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -1,7 +1,12 @@
 import { FlexBox, ProductImg, RegularText } from '../components/atoms';
 import { theme } from '../styles/theme';
 import { styled } from 'styled-components';
-import { ProductListItem, RowScrollContainer } from '../components/molecules';
+import {
+  ProductListItem,
+  ReviewItem,
+  RowScrollContainer,
+  WhiteButton,
+} from '../components/molecules';
 import { FaChevronRight } from 'react-icons/fa6';
 import {
   ProductDetailMain,
@@ -12,14 +17,16 @@ import {
 } from '../components/organisms';
 import {
   getProductDetailAPI,
+  getReviewsAPI,
   getReviewStatisticsAPI,
+  getCategoryProductsAPI,
 } from '../apis';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
-import { getCategoryProductsAPI } from '../apis/productAPI';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const ProductDetailPage = () => {
   const { productId } = useParams();
+  const navigate = useNavigate();
 
   const { data: { mainData, infoData, etcData } = {}, isSuccess } = useQuery({
     queryKey: ['product-detail', productId],
@@ -32,6 +39,18 @@ const ProductDetailPage = () => {
     queryFn: () => getReviewStatisticsAPI(parseInt(productId || '-1')),
     staleTime: 30 * 1000,
   });
+
+  const { data: reviewData } = useQuery({
+    queryKey: ['review-preview', productId],
+    queryFn: () =>
+      getReviewsAPI({
+        productId: parseInt(productId || '-1'),
+        lastViewedId: -1,
+        limit: 2,
+      }),
+    staleTime: 30 * 1000,
+  });
+
   const { data: relatedData } = useQuery({
     queryKey: ['related-products', productId],
     queryFn: () =>
@@ -54,6 +73,23 @@ const ProductDetailPage = () => {
 
       {/* 리뷰 */}
       <ReviewOverview data={reviewOverviewData} />
+      <FlexBox col>
+        {reviewData?.productReviews.map((item, idx) => (
+          <ReviewItem
+            key={item.id}
+            data={item}
+            isLastItem={reviewData?.productReviews.length === idx + 1}
+          />
+        ))}
+      </FlexBox>
+      {reviewData?.hasNextPage && (
+        <WhiteButton
+          text={`${reviewOverviewData?.totalReviewCount}  |  리뷰더보기`}
+          onClick={() => navigate(`/product/${productId}/review`)}
+          style={{ margin: '0 1.4rem', width: 'calc(100% - 2.8rem)' }}
+        />
+      )}
+
       {/* 추천 상품 */}
       <RowScrollContainer
         row={2}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -1,10 +1,17 @@
-import { ReviewOverview } from '../components/organisms';
+import { useState } from 'react';
+import {
+  ReviewList,
+  ReviewOverview,
+  ReviewModal,
+} from '../components/organisms';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import { getReviewStatisticsAPI } from '../apis/reviewAPI';
 
 const ReviewPage = () => {
   const { productId } = useParams();
+  const [isOpenModal, setIsOpenModal] = useState(false);
+  const [score, setScore] = useState<number | undefined>(undefined);
 
   const { data } = useQuery({
     queryKey: ['review-statistics', productId],
@@ -15,6 +22,15 @@ const ReviewPage = () => {
   return (
     <>
       <ReviewOverview data={data} />
+      <ReviewList score={score} setIsOpenModal={setIsOpenModal} />
+      {isOpenModal && (
+        <ReviewModal
+          setIsOpenModal={setIsOpenModal}
+          value={score}
+          setValue={setScore}
+          options={data?.scoreCounts || []}
+        />
+      )}
     </>
   );
 };

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -1,6 +1,7 @@
 import 'styled-components';
 
 interface Font {
+  bold30: RuleSet<object>;
   bold28: RuleSet<object>;
   bold24: RuleSet<object>;
   bold22: RuleSet<object>;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,5 +1,10 @@
 import { css } from 'styled-components';
 
+const bold30 = css`
+  font-size: 3rem;
+  font-weight: 700;
+`;
+
 const bold28 = css`
   font-size: 2.8rem;
   font-weight: 700;
@@ -158,6 +163,7 @@ const device = {
 };
 
 const font = {
+  bold30,
   bold28,
   bold24,
   bold22,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -16,3 +16,12 @@ export const formatFilter = (name: string) => {
       return name;
   }
 };
+
+export const formatDate = (date: string) => {
+  const formatDate = new Date(date);
+  const year = formatDate.getFullYear();
+  const month = String(formatDate.getMonth() + 1).padStart(2, '0');
+  const day = String(formatDate.getDate()).padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
+};


### PR DESCRIPTION
> Close #88

## 사진
### 상품 상세페이지 리뷰 파트
![image](https://github.com/petqua/frontend/assets/123801984/80adc6e7-4bb7-446a-893d-906e903453f9)

### 리뷰 상세페이지
![image](https://github.com/petqua/frontend/assets/123801984/bde82787-bfb8-4c0e-8efe-94b11599ed17)

## 커밋 리스트

#### ✅ refactor: BlueButton 리팩토링

- font-size와 margin 조건부 기능 추가

#### ✅ feat: ReviewItem molecule 컴포넌트 제작

- 리뷰 리스트에 들어가는 item
- 마지막 아이템인 경우 하단 border 제거

#### ✅ design: WhiteButton 색상 변경

#### ✅ feat: ReviewList organism 컴포넌트 제작

- 리뷰 상세페이지에서만 사용
- 필터링 기능
- 무한스크롤 기능

#### ✅ feat: 리뷰 조회 api 연동


#### ✅ feat: 리뷰 파트 페이지 구현


#### ✅ refactor: BoldText 사이즈 추가

- font-size 30 추가

#### ✅ refactor: 리뷰 요청사항 반영

- styled.d.ts에 bold30 추가

## Comment

- 내용이 좀 많은데 이미 연동이 다 되어있는 작업에다가 새로 만든 파일이면은 부분 적용이 또 안되는 불편함이 있어서 그냥 합쳐서 한번에 올릴게요..ㅎ
