### PR TITLE
[#100] 캐러셀 스와이프 기능 추가

### DIFF
--- a/src/components/molecules/Carousel.tsx
+++ b/src/components/molecules/Carousel.tsx
@@ -79,6 +79,39 @@ const Carousel = ({ carouselList }: Carousel) => {
     }
   };
 
+  let touchStartX: number;
+  let touchEndX: number;
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    touchStartX = e.nativeEvent.touches[0].clientX;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    const curTouchX = e.nativeEvent.changedTouches[0].clientX;
+    if (carouselRef.current !== null) {
+      carouselRef.current.style.transition = '';
+      carouselRef.current.style.transform = `translateX(calc(-${curIdx + 1}00% - ${
+        touchStartX - curTouchX
+      }px))`;
+    }
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    touchEndX = e.nativeEvent.changedTouches[0].clientX;
+    const moveToNext = touchStartX - touchEndX > 50;
+    const moveToPrev = touchEndX - touchStartX > 50;
+    if (moveToNext) {
+      handleClick(1);
+    } else if (moveToPrev) {
+      handleClick(-1);
+    } else {
+      if (carouselRef.current !== null) {
+        carouselRef.current.style.transition = 'all 0.5s ease-in-out';
+        carouselRef.current.style.transform = `translateX(-${curIdx + 1}00%)`;
+      }
+    }
+  };
+
   useEffect(() => {
     if (carouselRef.current !== null) {
       carouselRef.current.style.transform = `translateX(-${curIdx + 1}00%)`;
@@ -90,7 +123,12 @@ const Carousel = ({ carouselList }: Carousel) => {
       <Button onClick={() => handleClick(-1)} $isLeft={true}>
         <IoIosArrowBack size={36} />
       </Button>
-      <CarouselBox ref={carouselRef}>
+      <CarouselBox
+        ref={carouselRef}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
         {carouselArray.map(
           (val, idx) => val && <Img key={idx} src={val.imageUrl} />,
         )}


### PR DESCRIPTION
> Close #100 

## Preview
https://frontend-git-100-blueapple99s-projects.vercel.app/

## 구현
```tsx
  let touchStartX: number;
  let touchEndX: number;
  // 처음 터치했을 때 호출하는 함수. 처음 터치한 곳의 x위치를 할당한다.
  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
    touchStartX = e.nativeEvent.touches[0].clientX;
  };
  // 터치를 하는 과정에서 호출하는 함수. 
  // 터치를 한 만큼 다음사진으로 움직인다.
  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
    const curTouchX = e.nativeEvent.changedTouches[0].clientX;
    if (carouselRef.current !== null) {
      carouselRef.current.style.transition = '';
      carouselRef.current.style.transform = `translateX(calc(-${curIdx + 1}00% - ${
        touchStartX - curTouchX
      }px))`;
    }
  };
  // 터치가 끝났을 때 호출하는 함수. 
  // 터치의 끝점과 시작점의 차이를 고려하여 50의 차이가 있으면 넘길만하다고 판단
  // 50을 넘지 못하면 애니메이션 효과와 함께 원래 위치로 이동
  const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
    touchEndX = e.nativeEvent.changedTouches[0].clientX;
    const moveToNext = touchStartX - touchEndX > 50;
    const moveToPrev = touchEndX - touchStartX > 50;
    if (moveToNext) {
      handleClick(1);
    } else if (moveToPrev) {
      handleClick(-1);
    } else {
      if (carouselRef.current !== null) {
        carouselRef.current.style.transition = 'all 0.5s ease-in-out';
        carouselRef.current.style.transform = `translateX(-${curIdx + 1}00%)`;
      }
    }
  };
```

## 커밋 리스트

#### ✅ feat: 캐러셀 스와이프 기능 추가

- 스와이프로 슬라이드 이동하는 기능 구현

## Comment

- 스와이프로 슬라이드 가능하게 해놓았는데 모바일 환경에서 좌우 이동 버튼 없앨지 말지 고민중입니다.
 스와이프 어색한 유저들 생각하면 있는게 나은가 싶다가도, 너무 과한 걱정인가도 싶네요. ㅋㅋ
