### PR TITLE
[#108] 상품 후기 추천 api 연동

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -5,7 +5,11 @@ import {
   getCategoryProductsAPI,
 } from './productAPI';
 import { getSearchProductsAPI, getTrendingKeywordsAPI } from './searchAPI';
-import { getReviewStatisticsAPI, getReviewsAPI } from './reviewAPI';
+import {
+  getReviewStatisticsAPI,
+  getReviewsAPI,
+  postReviewRecommendAPI,
+} from './reviewAPI';
 import { getWishesAPI, postWishAPI } from './wishAPI';
 import {
   getAccessTokenAPI,
@@ -27,6 +31,7 @@ export {
   getProductDetailAPI,
   getReviewsAPI,
   getReviewStatisticsAPI,
+  postReviewRecommendAPI,
   getDefaultAddressAPI,
   postNewAddressAPI,
   getCartsAPI,

--- a/src/apis/reviewAPI.ts
+++ b/src/apis/reviewAPI.ts
@@ -70,3 +70,19 @@ export const getReviewStatisticsAPI = async (
     throw error;
   }
 };
+
+export const postReviewRecommendAPI = async (productReviewId: number) => {
+  try {
+    const res = await client.post('/product-reviews/recommendation', {
+      productReviewId,
+    });
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      console.error('Server Error:', error.response.data);
+    } else {
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/components/molecules/ReviewItem.tsx
+++ b/src/components/molecules/ReviewItem.tsx
@@ -11,8 +11,29 @@ import {
 import { FaRegThumbsUp, FaThumbsUp } from 'react-icons/fa6';
 import { ReviewItem } from '../../interfaces/review';
 import { formatDate } from '../../utils/format';
+import { useMutation } from '@tanstack/react-query';
+import { postReviewRecommendAPI } from '../../apis';
+import { useState } from 'react';
 
 const ReviewItem = ({ data, isRecommend, isLastItem }: ReviewItem) => {
+  const [showRecommended, setShowRecommended] = useState(data?.recommended);
+  const [showRecommendCount, setShowRecommendCount] = useState(
+    data?.recommendCount,
+  );
+
+  const { mutate } = useMutation({
+    mutationFn: () => postReviewRecommendAPI(data?.id),
+    onSuccess: () => {
+      setShowRecommended((prev) => !prev);
+      showRecommended
+        ? setShowRecommendCount((prev) => prev - 1)
+        : setShowRecommendCount((prev) => prev + 1);
+    },
+    onError: (err) => {
+      console.error(err);
+    },
+  });
+
   return (
     <>
       <FlexBox col padding="2.4rem 0" gap="1.6rem" style={{ width: '100%' }}>
@@ -59,8 +80,8 @@ const ReviewItem = ({ data, isRecommend, isLastItem }: ReviewItem) => {
         </RegularText>
 
         {isRecommend && (
-          <RecommendBtn>
-            {data?.recommended ? (
+          <RecommendBtn onClick={() => mutate()}>
+            {showRecommended ? (
               <FaThumbsUp size={16} color={theme.color.blue.main} />
             ) : (
               <FaRegThumbsUp size={16} color={theme.color.gray[50]} />
@@ -68,10 +89,10 @@ const ReviewItem = ({ data, isRecommend, isLastItem }: ReviewItem) => {
             <RegularText
               size={14}
               color={
-                data?.recommended ? theme.color.gray.main : theme.color.gray[50]
+                showRecommended ? theme.color.gray.main : theme.color.gray[50]
               }
             >
-              추천 {data?.recommendCount}
+              추천 {showRecommendCount}
             </RegularText>
           </RecommendBtn>
         )}

--- a/src/components/organisms/ReviewList.tsx
+++ b/src/components/organisms/ReviewList.tsx
@@ -36,8 +36,7 @@ const ReviewList = ({ score, setIsOpenModal }: ReviewList) => {
       if (!lastPage.hasNextPage) return undefined;
       return lastPage.productReviews[length].id;
     },
-    staleTime: 60 * 1000,
-    gcTime: 0,
+    staleTime: 0,
   });
 
   const handleSorter = (type: string) => {

--- a/src/components/organisms/ReviewList.tsx
+++ b/src/components/organisms/ReviewList.tsx
@@ -37,6 +37,7 @@ const ReviewList = ({ score, setIsOpenModal }: ReviewList) => {
       return lastPage.productReviews[length].id;
     },
     staleTime: 60 * 1000,
+    gcTime: 0,
   });
 
   const handleSorter = (type: string) => {


### PR DESCRIPTION
> Close #108

## 사진
![image](https://github.com/petqua/frontend/assets/123801984/363dc831-3938-4691-b709-1165ad9ec849)

## 커밋 리스트

#### ✅ feat: 상품후기 추천 api 연동

- gcTime을 0으로 설정해서 페이지 mount시 새로 데이터 받아옴

## Comment

### gcTime을 0으로 설정한 이유
- 추천버튼으로 토글을 진행할 때마다 **전체 review 데이터를 refetch하는 것은 비효율적이라고 생각**해서 나타나는 표시형식의 상태를 프론트 측에서 관리
- gcTime을 0으로 설정할 경우 **다른 페이지를 갔다올 경우 다시 최상단으로 올라오는 불편함이 존재**하는데 플로우 상 **리뷰 리스트에서 상세페이지로 돌아가는 플로우밖에 존재하지 않기에** 캐싱작업이 필요하지 않을것 같다고 판단