### PR TITLE
[#81] 상품 상세페이지 이미지 캐러샐 제작

### DIFF
--- a/src/apis/productAPI.ts
+++ b/src/apis/productAPI.ts
@@ -47,21 +47,23 @@ export const getProductDetailAPI = async (
       storeName,
       discountRate,
       discountPrice,
+      wishCount,
       reviewCount,
       reviewAverageScore,
-      description,
+      imageUrls,
+      // descriptionTitle,
+      // descriptionContent,
+      descriptionImageUrls,
+      // safeDeliveryFee,
+      // commonDeliveryFee,
+      // pickUpDeliveryFee,
       optimalTemperatureMin,
       optimalTemperatureMax,
       difficultyLevel,
       optimalTankSize,
       temperament,
-      descriptionImageUrls,
-      thumbnailUrl,
-      wishCount,
-      canDeliverSafely,
-      canDeliverCommonly,
-      canPickUp,
-      hasDistinctSex,
+      // maleAdditionalPrice,
+      // femaleAdditionalPrice,
       isWished,
     } = data;
 
@@ -76,7 +78,6 @@ export const getProductDetailAPI = async (
       discountPrice,
       reviewCount,
       reviewAverageScore,
-      description,
     };
 
     const infoData = {
@@ -90,13 +91,11 @@ export const getProductDetailAPI = async (
     };
 
     const etcData = {
+      imageUrls,
+      // descriptionTitle,
+      // descriptionContent,
       descriptionImageUrls,
-      thumbnailUrl,
       wishCount,
-      canDeliverSafely,
-      canDeliverCommonly,
-      canPickUp,
-      hasDistinctSex,
       isWished,
     };
 

--- a/src/components/atoms/ProductImg.tsx
+++ b/src/components/atoms/ProductImg.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 interface ProductImg {
   size: string;
   src: string;
-  isRound?: boolean;
   showWish?: boolean;
   isWish?: boolean;
   onClickWish?: UseMutateFunction<any, Error, void, unknown>;
@@ -15,7 +14,6 @@ const ProductImg = ({
   src,
   showWish,
   isWish,
-  isRound,
   onClickWish,
 }: ProductImg) => {
   return (
@@ -23,7 +21,6 @@ const ProductImg = ({
       <Image
         src={src || '/public/images/product-item-ex.svg'}
         alt="product-img"
-        style={{ borderRadius: isRound ? '1.2rem' : '' }}
       />
       {showWish && (
         <WishBtn
@@ -47,12 +44,14 @@ const ImgContainer = styled.div`
   aspect-ratio: 1;
   overflow: hidden;
   position: relative;
+  border-radius: 1.2rem;
 `;
 
 const Image = styled.img`
   width: 100%;
   height: 100%;
   object-fit: contain;
+  border-radius: 1.2rem;
 `;
 
 const WishBtn = styled.img`

--- a/src/components/molecules/Carousel.tsx
+++ b/src/components/molecules/Carousel.tsx
@@ -1,55 +1,23 @@
 import styled from 'styled-components';
-import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 import { useEffect, useRef, useState } from 'react';
+import { ImageDetail } from '../organisms';
+import { RegularText } from '../atoms';
+import { theme } from '../../styles/theme';
+import { GrNext, GrPrevious } from 'react-icons/gr';
+import { Carousel } from '../../interfaces/carousel';
 
-const Container = styled.div`
-  position: relative;
-  width: 100%;
-  height: 38rem;
-  @media ${({ theme }) => theme.device.mobile} {
-    height: 26rem;
-  }
-  overflow-x: clip;
-`;
-
-const CarouselBox = styled.div`
-  display: flex;
-  width: 100%;
-  height: 100%;
-`;
-
-const Img = styled.img`
-  min-width: 100%;
-  width: 100%;
-  height: 100%;
-`;
-
-interface Button {
-  $isLeft: boolean;
-}
-
-const Button = styled.button<Button>`
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  ${({ $isLeft }) => ($isLeft ? 'left: 0;' : 'right: 0;')}
-  z-index: 1;
-`;
-
-interface Banner {
-  id: string;
-  imageUrl: string;
-  linkUrl: string;
-}
-
-interface Carousel {
-  carouselList: Array<Banner>;
-}
-
-const Carousel = ({ carouselList }: Carousel) => {
+const Carousel = ({
+  carouselList,
+  canShowDetail,
+  isDetail,
+  idx,
+  isBlackIndicator,
+}: Carousel) => {
+  const [isOpenDetail, setIsOpenDetail] = useState(false);
   const carouselRef = useRef<HTMLDivElement>(null);
+  const imgsRef = useRef<HTMLImageElement[] | null[]>([]);
 
-  const [curIdx, setCurIdx] = useState(0);
+  const [curIdx, setCurIdx] = useState(idx || 0);
 
   const carouselArray = [
     carouselList[carouselList.length - 1],
@@ -76,6 +44,9 @@ const Carousel = ({ carouselList }: Carousel) => {
     setCurIdx(nextIdx);
     if (carouselRef.current !== null) {
       carouselRef.current.style.transition = 'all 0.5s ease-in-out';
+      isDetail &&
+        (carouselRef.current.style.height =
+          (imgsRef.current[nextIdx + 1]?.offsetHeight || 0) + 'px');
     }
   };
 
@@ -119,25 +90,110 @@ const Carousel = ({ carouselList }: Carousel) => {
   }, [curIdx]);
 
   return (
-    <Container>
-      <Button onClick={() => handleClick(-1)} $isLeft={true}>
-        <IoIosArrowBack size={36} />
-      </Button>
-      <CarouselBox
-        ref={carouselRef}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-      >
-        {carouselArray.map(
-          (val, idx) => val && <Img key={idx} src={val.imageUrl} />,
-        )}
-      </CarouselBox>
-      <Button onClick={() => handleClick(1)} $isLeft={false}>
-        <IoIosArrowForward size={36} />
-      </Button>
-    </Container>
+    <>
+      <Container>
+        <Button onClick={() => handleClick(-1)} $isLeft={true}>
+          <GrPrevious size={24} color={theme.color.gray.main} />
+        </Button>
+        <CarouselBox
+          ref={carouselRef}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          onClick={() => canShowDetail && setIsOpenDetail(true)}
+          $isDetail={isDetail || false}
+        >
+          {carouselArray.map(
+            (val, idx) =>
+              val && (
+                <Img
+                  key={idx}
+                  src={val.imageUrl}
+                  ref={(ref) => (imgsRef.current[idx] = ref)}
+                  $isDetail={isDetail || false}
+                />
+              ),
+          )}
+        </CarouselBox>
+        <Button onClick={() => handleClick(1)} $isLeft={false}>
+          <GrNext size={24} color={theme.color.gray.main} />
+        </Button>
+        <Indicator
+          $isDetail={isDetail || false}
+          $isBlackIndicator={isBlackIndicator || false}
+        >
+          <RegularText
+            size={14}
+            color={isDetail ? theme.color.gray.main : theme.color.tint.white}
+          >
+            {curIdx + 1} / {carouselList.length}
+          </RegularText>
+        </Indicator>
+      </Container>
+      {isOpenDetail && (
+        <ImageDetail
+          setIsOpenDetail={setIsOpenDetail}
+          carouselList={carouselList}
+          idx={curIdx || 0}
+        />
+      )}
+    </>
   );
 };
 
 export default Carousel;
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+  overflow-x: clip;
+`;
+
+const CarouselBox = styled.div<{ $isDetail: boolean }>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  aspect-ratio: ${({ $isDetail }) => ($isDetail ? '' : '1.32')};
+`;
+
+const Img = styled.img<{ $isDetail: boolean }>`
+  min-width: 100%;
+  width: 100%;
+  height: ${({ $isDetail }) => ($isDetail ? '' : '100%')};
+  object-fit: contain;
+`;
+
+const Button = styled.button<{ $isLeft: boolean }>`
+  padding: 1.6rem 0.4rem;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  background: rgba(222, 234, 255, 0.3);
+  ${({ $isLeft }) =>
+    $isLeft
+      ? 'left: 0; border-radius: 0px 8px 8px 0px;'
+      : 'right: 0; border-radius: 8px 0px 0px 8px;'}
+`;
+
+const Indicator = styled.div<{
+  $isDetail: boolean;
+  $isBlackIndicator: boolean;
+}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  padding: 0.6rem 1.2rem;
+  border-radius: 2rem;
+  background: ${({ $isDetail, $isBlackIndicator }) =>
+    $isDetail
+      ? 'rgba(255, 255, 255, 0.30)'
+      : $isBlackIndicator
+        ? 'rgba(0, 0, 0, 0.70)'
+        : 'rgba(0, 0, 0, 0.35)'};
+  ${({ $isDetail }) =>
+    $isDetail
+      ? 'bottom: -4rem; left: 50%; transform: translateX(-50%); border: 0.05rem solid ${({ theme }) => theme.color.gray[50]};'
+      : 'right: 1rem; bottom: 1.2rem;'};
+`;

--- a/src/components/molecules/Carousel.tsx
+++ b/src/components/molecules/Carousel.tsx
@@ -46,7 +46,7 @@ const Carousel = ({
       carouselRef.current.style.transition = 'all 0.5s ease-in-out';
       isDetail &&
         (carouselRef.current.style.height =
-          (imgsRef.current[nextIdx + 1]?.offsetHeight || 0) + 'px');
+          (imgsRef.current[nextIdx + 1]?.offsetHeight || 0) / 10 + 'rem');
     }
   };
 
@@ -182,8 +182,8 @@ const Button = styled.button<{ $isLeft: boolean }>`
   background: rgba(222, 234, 255, 0.3);
   ${({ $isLeft }) =>
     $isLeft
-      ? 'left: 0; border-radius: 0px 8px 8px 0px;'
-      : 'right: 0; border-radius: 8px 0px 0px 8px;'}
+      ? 'left: 0; border-radius: 0 0.8rem 0.8rem 0;'
+      : 'right: 0; border-radius: 0.8rem 0 0 0.8rem;'}
 `;
 
 const Indicator = styled.div<{

--- a/src/components/molecules/Carousel.tsx
+++ b/src/components/molecules/Carousel.tsx
@@ -89,6 +89,16 @@ const Carousel = ({
     }
   }, [curIdx]);
 
+  const formatIndex = (idx: number) => {
+    if (idx < 1) {
+      return carouselList.length;
+    } else if (idx > carouselList.length) {
+      return 1;
+    } else {
+      return idx;
+    }
+  };
+
   return (
     <>
       <Container>
@@ -126,7 +136,7 @@ const Carousel = ({
             size={14}
             color={isDetail ? theme.color.gray.main : theme.color.tint.white}
           >
-            {curIdx + 1} / {carouselList.length}
+            {formatIndex(curIdx + 1)} / {carouselList.length}
           </RegularText>
         </Indicator>
       </Container>

--- a/src/components/molecules/ProductListItem.tsx
+++ b/src/components/molecules/ProductListItem.tsx
@@ -53,7 +53,6 @@ const ProductListItem = ({ isMain, isSmall, data }: ProductListItem) => {
         showWish={!isSmall && !isMain}
         isWish={showIsWished}
         onClickWish={mutate}
-        isRound
       />
 
       <FlexBox col gap="0.8rem" style={{ flex: isMain ? 1 : 0 }}>

--- a/src/components/molecules/ReviewItem.tsx
+++ b/src/components/molecules/ReviewItem.tsx
@@ -45,7 +45,7 @@ const ReviewItem = ({ data, isRecommend, isLastItem }: ReviewItem) => {
         {data?.images.length !== 0 && (
           <RowScrollContainer gap="0.8rem" row={1} col={5}>
             {data?.images.map((item, idx) => (
-              <ProductImg key={idx} size="12rem" isRound src={item} />
+              <ProductImg key={idx} size="12rem" src={item} />
             ))}
           </RowScrollContainer>
         )}

--- a/src/components/organisms/ImageDetail.tsx
+++ b/src/components/organisms/ImageDetail.tsx
@@ -9,7 +9,7 @@ import { ImageDetail } from '../../interfaces/carousel';
 const ImageDetail = ({ setIsOpenDetail, idx, carouselList }: ImageDetail) => {
   const [visible, setVisible] = useState(true);
 
-  const handleCloseConfirm = () => {
+  const handleCloseViewer = () => {
     setVisible(false);
     setTimeout(() => {
       setIsOpenDetail(false);
@@ -30,22 +30,22 @@ const ImageDetail = ({ setIsOpenDetail, idx, carouselList }: ImageDetail) => {
   }, []);
 
   return (
-    <ConfirmOverlay $visible={visible}>
+    <ViewerOverlay $visible={visible}>
       <CloseBtn>
         <IoCloseOutline
           size={32}
           color={theme.color.tint.white}
-          onClick={handleCloseConfirm}
+          onClick={handleCloseViewer}
         />
       </CloseBtn>
       <Carousel carouselList={carouselList} isDetail idx={idx} />
-    </ConfirmOverlay>
+    </ViewerOverlay>
   );
 };
 
 export default ImageDetail;
 
-const ConfirmOverlay = styled.div<{ $visible: boolean }>`
+const ViewerOverlay = styled.div<{ $visible: boolean }>`
   width: 100%;
   max-width: 50rem;
   height: 100vh;
@@ -61,7 +61,6 @@ const ConfirmOverlay = styled.div<{ $visible: boolean }>`
   z-index: 100;
   background-color: rgba(0, 0, 0, 0.8);
   overflow: ${({ $visible }) => ($visible ? 'hidden' : 'auto')};
-
   animation: ${({ $visible }) => ($visible ? fadeIn : fadeOut)} 0.2s ease-in-out;
 `;
 

--- a/src/components/organisms/ImageDetail.tsx
+++ b/src/components/organisms/ImageDetail.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { styled } from 'styled-components';
+import { fadeIn, fadeOut } from '../../styles/keyframes';
+import { theme } from '../../styles/theme';
+import { Carousel } from '../molecules';
+import { IoCloseOutline } from 'react-icons/io5';
+import { ImageDetail } from '../../interfaces/carousel';
+
+const ImageDetail = ({ setIsOpenDetail, idx, carouselList }: ImageDetail) => {
+  const [visible, setVisible] = useState(true);
+
+  const handleCloseConfirm = () => {
+    setVisible(false);
+    setTimeout(() => {
+      setIsOpenDetail(false);
+    }, 150);
+  };
+
+  useEffect(() => {
+    document.body.style.cssText = `
+            position: fixed; 
+            top: -${window.scrollY}px;
+            overflow-y: scroll;
+            width: 100%;`;
+    return () => {
+      const scrollY = document.body.style.top;
+      document.body.style.cssText = '';
+      window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+    };
+  }, []);
+
+  return (
+    <ConfirmOverlay $visible={visible}>
+      <CloseBtn>
+        <IoCloseOutline
+          size={32}
+          color={theme.color.tint.white}
+          onClick={handleCloseConfirm}
+        />
+      </CloseBtn>
+      <Carousel carouselList={carouselList} isDetail idx={idx} />
+    </ConfirmOverlay>
+  );
+};
+
+export default ImageDetail;
+
+const ConfirmOverlay = styled.div<{ $visible: boolean }>`
+  width: 100%;
+  max-width: 50rem;
+  height: 100vh;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.6rem;
+  z-index: 100;
+  background-color: rgba(0, 0, 0, 0.8);
+  overflow: ${({ $visible }) => ($visible ? 'hidden' : 'auto')};
+
+  animation: ${({ $visible }) => ($visible ? fadeIn : fadeOut)} 0.2s ease-in-out;
+`;
+
+const CloseBtn = styled.button`
+  position: absolute;
+  top: 4rem;
+  right: 2rem;
+  z-index: 1;
+`;

--- a/src/components/organisms/ProductDetailMain.tsx
+++ b/src/components/organisms/ProductDetailMain.tsx
@@ -62,7 +62,8 @@ const ProductDetailMain = ({ data }: ProductDetailMain) => {
         color={theme.color.gray[70]}
         style={{ lineHeight: '160%' }}
       >
-        {data?.description}
+        {/* {data?.description} */}
+        상품 상세내용 작업 중...
       </RegularText>
     </FlexBox>
   );

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -14,6 +14,7 @@ import ReviewModal from './modals/ReviewModal';
 import OptionModal from './modals/OptionModal';
 import CartFishList from './CartFishList';
 import CartList from './CartList';
+import ImageDetail from './ImageDetail';
 
 export {
   CategoryList,
@@ -32,4 +33,5 @@ export {
   CartFishList,
   OptionModal,
   CartList,
+  ImageDetail,
 };

--- a/src/interfaces/carousel.ts
+++ b/src/interfaces/carousel.ts
@@ -1,0 +1,21 @@
+import { SetStateAction } from 'react';
+
+export interface CarouselItem {
+  id: number;
+  imageUrl: string;
+  linkUrl: string;
+}
+
+export interface Carousel {
+  carouselList: CarouselItem[];
+  canShowDetail?: boolean;
+  isDetail?: boolean;
+  idx?: number;
+  isBlackIndicator?: boolean;
+}
+
+export interface ImageDetail {
+  setIsOpenDetail: React.Dispatch<SetStateAction<boolean>>;
+  idx: number;
+  carouselList: CarouselItem[];
+}

--- a/src/interfaces/product.ts
+++ b/src/interfaces/product.ts
@@ -61,7 +61,6 @@ export interface ProductDetailMainData {
   discountPrice: number;
   reviewCount: number;
   reviewAverageScore: number;
-  description: string;
 }
 
 export interface ProductDetailInfoData {
@@ -104,13 +103,9 @@ export interface GetProductDetailAPI {
   infoData: ProductDetailInfoData;
   etcData: {
     descriptionImageUrls: string[];
-    thumbnailUrl: string;
     wishCount: number;
-    canDeliverSafely: boolean;
-    canDeliverCommonly: boolean;
-    canPickUp: boolean;
-    hasDistinctSex: boolean;
     isWished?: boolean;
+    imageUrls?: string[];
   };
 }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,22 +11,22 @@ import { getAnnouncementsAPI, getBannersAPI } from '../apis';
 // 일단 서버에서 내려주는 값이 없어서 이렇게 해놓음.
 const CAROUSEL_MOCK_DATA = [
   {
-    id: '1L',
+    id: 1,
     imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },
   {
-    id: '2L',
+    id: 2,
     imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },
   {
-    id: '3L',
+    id: 3,
     imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },
   {
-    id: '4L',
+    id: 4,
     imageUrl: 'https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg',
     linkUrl: 'https://www.naver.com/',
   },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -49,9 +49,9 @@ const HomePage = () => {
     <>
       <TopNav alarm search basket logo />
       {bannersList && bannersList.length !== 0 ? (
-        <Carousel carouselList={bannersList} />
+        <Carousel carouselList={bannersList} isBlackIndicator />
       ) : (
-        <Carousel carouselList={CAROUSEL_MOCK_DATA} />
+        <Carousel carouselList={CAROUSEL_MOCK_DATA} isBlackIndicator />
       )}
       <Notification announcementList={announcementList} />
       <CategoryList />

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -2,6 +2,7 @@ import { FlexBox, ProductImg, RegularText } from '../components/atoms';
 import { theme } from '../styles/theme';
 import { styled } from 'styled-components';
 import {
+  Carousel,
   ProductListItem,
   ReviewItem,
   RowScrollContainer,
@@ -65,7 +66,16 @@ const ProductDetailPage = () => {
 
   return (
     <>
-      <ProductImg size="100%" src={etcData?.thumbnailUrl || ''} />
+      <Carousel
+        carouselList={
+          etcData?.imageUrls?.map((url, idx) => ({
+            id: idx,
+            imageUrl: url,
+            linkUrl: '',
+          })) || []
+        }
+        canShowDetail
+      />
       <ProductDetailMain data={mainData} />
       <Notice src="/images/notice-ex.svg" alt="product-detail-notice" />
       <ProductDetailInfo data={infoData} />

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -1,6 +1,6 @@
-import { FlexBox, ProductImg, RegularText } from '../components/atoms';
 import { theme } from '../styles/theme';
 import { styled } from 'styled-components';
+import { FlexBox, RegularText } from '../components/atoms';
 import {
   Carousel,
   ProductListItem,


### PR DESCRIPTION
> Close #81 

## 사진
### 상세 페이지 이미지 캐러샐
![image](https://github.com/petqua/frontend/assets/123801984/29be98ed-ac1b-40c6-a195-b2dac2b3f0f9)

### 이미지 상세보기
![image](https://github.com/petqua/frontend/assets/123801984/39aed222-0c55-4f97-b5a3-dc1c3e1c888d)

### 홈 페이지 공지 캐러샐
![image](https://github.com/petqua/frontend/assets/123801984/6583478f-cfe4-407b-80b3-0aa2bcc22303)

## 커밋 리스트

#### ✅ refactor: productImg border-radius 조건 제거

#### ✅ feat: ImageDetail organism 제작

- 이미지의 현재 위치부터 상세보기 기능

#### ✅ feat: 캐러샐 기능 수정

- 상황 별로 디자인 변경
- index indicator, 양옆 화살표 디자인 변경

#### ✅ refactor: 상품 상세보기 api 수정

- response 일부 수정

#### ✅ refactor: build 오류 해결

#### ✅ feat: 범위 초과 index 표시 오류 수정

## Comment

- 이미지 상세보기에서는 이미지의 높이에 따라 하단의 indicator의 위치가 변경합니다.
- 이미지 상세보기에서는 캐러샐을 제외한 검은 배경 부분을 클릭하더라도 상세보기가 종료되지 않도록 했어요. X 버튼이 존재하는데 모든 배경을 클릭해서 종료가 되는거면 X버튼의 존재 이유가 없다고 판단하였기 때문입니다.
- 캐러샐에 나타나는 이미지 전부 `object-fit: contain`으로 했습니다. 홈페이지 공지의 경우 해당 사이즈에 맞게 제작이 될거라 예외없이 동일하게 적용했습니다.