### PR TITLE
[#113] 결제 정보 컴포넌트 구현

### DIFF
--- a/src/components/molecules/PaymentInfo.tsx
+++ b/src/components/molecules/PaymentInfo.tsx
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+import { theme } from '../../styles/theme';
+import { BoldText } from '../atoms';
+
+const Container = styled.section`
+  padding: 2.4rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;
+
+const GridBox = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  column-gap: 1.3rem;
+  row-gap: 1.4rem;
+`;
+
+const Button = styled.button<{ $isSelected: boolean }>`
+  ${({ theme }) => theme.font.regular14}
+  height: 4.8rem;
+  border-radius: 0.6rem;
+  border: ${({ theme, $isSelected }) =>
+    $isSelected
+      ? `0.1rem solid ${theme.color.blue[70]}`
+      : `0.05rem solid ${theme.color.gray[50]}`};
+  color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.color.blue[70] : theme.color.gray.main};
+`;
+
+const PAYMENT_TYPE = [
+  '신용/체크카드',
+  '간편카드결제',
+  '페이코',
+  '토스페이',
+  '카카오페이',
+  '네이버페이',
+  '휴대폰결제',
+  '실시간 계좌이체',
+];
+
+interface PaymentInfo {
+  paymentType: string;
+  setPaymentType: (paymentType: string) => void;
+}
+
+const PaymentInfo = ({ paymentType, setPaymentType }: PaymentInfo) => {
+  const handleClick = (paymentType: string) => {
+    setPaymentType(paymentType);
+  };
+
+  return (
+    <Container>
+      <BoldText size={18} color={theme.color.gray.main}>
+        결제정보
+      </BoldText>
+      <GridBox>
+        {PAYMENT_TYPE.map((payment_type, idx) => (
+          <Button
+            key={idx}
+            $isSelected={paymentType === payment_type}
+            onClick={() => handleClick(payment_type)}
+          >
+            {payment_type}
+          </Button>
+        ))}
+      </GridBox>
+    </Container>
+  );
+};
+
+export default PaymentInfo;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -23,6 +23,7 @@ import ReviewItem from './ReviewItem';
 import PopUp from './PopUp';
 import Confirm from './Confirm';
 import CartItem from './CartItem';
+import PaymentInfo from './PaymentInfo';
 
 export {
   ProductListItem,
@@ -50,4 +51,5 @@ export {
   PopUp,
   Confirm,
   CartItem,
+  PaymentInfo,
 };

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { AddressForm, TopNav } from '../components/molecules';
+import { AddressForm, PaymentInfo, TopNav } from '../components/molecules';
 import { getCartsAPI, getDefaultAddressAPI } from '../apis';
 import { useEffect, useState } from 'react';
 import { usePaymentStore } from '../states';
@@ -25,6 +25,8 @@ const PaymentPage = () => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const [paymentType, setPaymentType] = useState('신용/체크카드');
+
   useEffect(() => {
     if (address !== null) return;
     if (defaultAddressData) {
@@ -39,6 +41,7 @@ const PaymentPage = () => {
       <CustomHr height="0.8rem" color={theme.color.gray[30]} />
       <CartFishList cartData={cartData} />
       <CustomHr height="0.8rem" color={theme.color.gray[30]} />
+      <PaymentInfo paymentType={paymentType} setPaymentType={setPaymentType} />
       {isModalOpen && (
         <DeliveryAddressModal
           title="운송지 추가"


### PR DESCRIPTION
> Close #113 

## Preview
https://frontend-git-113-blueapple99s-projects.vercel.app/

## 사진
![image](https://github.com/petqua/frontend/assets/87417773/6efe7ac8-2331-4cae-b56a-b3a4b1d5c460)


## 커밋 리스트

#### ✅ feat: 결제 정보 컴포넌트 구현

- PaymentInfo (molecules) 추가
- 버튼 선택시 색상 변경