### PR TITLE
[#115] 결제 어종 정보 수정사항 반영

### DIFF
--- a/src/components/molecules/CartFish.tsx
+++ b/src/components/molecules/CartFish.tsx
@@ -6,6 +6,7 @@ import { theme } from '../../styles/theme';
 import {
   getBackgroundColor,
   getKoreanDeliveryMethod,
+  getSex,
   getTextColor,
 } from '../../utils/payment';
 
@@ -84,9 +85,9 @@ const CartFish = memo((props: CartItemDetails) => {
             color={theme.color.gray[50]}
             style={{ marginTop: '1.3rem' }}
           >
-            {quantity}마리 | {sex === 'MALE' ? '수컷' : '암컷'}
+            {quantity}마리 | {getSex(sex)}
           </RegularText>
-          <FlexBox gap="0.8rem" style={{ width: '100%' }}>
+          <FlexBox gap="0.8rem" fullWidth>
             {isOnSale && (
               <>
                 <MediumText size={12} color={theme.color.tint.red}>

--- a/src/components/molecules/CartFish.tsx
+++ b/src/components/molecules/CartFish.tsx
@@ -3,11 +3,19 @@ import { CartItemDetails } from '../../interfaces/payment';
 import { memo } from 'react';
 import { FlexBox, MediumText, RegularText } from '../atoms';
 import { theme } from '../../styles/theme';
+import {
+  getBackgroundColor,
+  getKoreanDeliveryMethod,
+  getTextColor,
+} from '../../utils/payment';
 
 const Container = styled.div`
-  padding: 1.2rem 0.7rem;
+  padding: 1rem 1.7rem;
   display: flex;
-  gap: 1.4rem;
+  flex-direction: column;
+  gap: 1rem;
+  background-color: ${({ theme }) => theme.color.tint.white};
+  border-radius: 1.2rem;
 `;
 
 const ImageBox = styled.div`
@@ -23,57 +31,95 @@ const ImageBox = styled.div`
   }
 `;
 
+const DeliveryMethodBox = styled.div<{ $method: string }>`
+  background-color: ${({ $method }) => getBackgroundColor($method)};
+  color: ${({ $method }) => getTextColor($method)};
+  ${({ theme }) => theme.font.bold10}
+  border-radius: 0.6rem;
+  padding: 0.2rem 0.45rem;
+  min-width: 4.5rem;
+`;
+
+const PriceInfoContainer = styled.div`
+  border-radius: 3rem;
+  border: 0.05rem solid ${({ theme }) => theme.color.blue[70]};
+  padding: 0.7rem 2.3rem;
+  ${({ theme }) => theme.font.medium12}
+  color: ${({ theme }) => theme.color.blue[70]};
+  text-align: center;
+`;
+
 const CartFish = memo((props: CartItemDetails) => {
   const {
     productThumbnailUrl,
-    storeName,
     productName,
     quantity,
-    isMale,
+    sex,
     isOnSale,
     productDiscountRate,
     productDiscountPrice,
     productPrice,
+    deliveryMethod,
+    deliveryFee,
   } = props;
+
+  const totalPrice = productDiscountPrice + deliveryFee;
   return (
     <Container>
-      <ImageBox>
-        <img src={productThumbnailUrl} alt={productName} />
-      </ImageBox>
-      <FlexBox col gap="0.8rem" style={{ flex: 1 }}>
-        <RegularText size={14} color={theme.color.gray[50]}>
-          {storeName}
-        </RegularText>
-        <MediumText size={18} color={theme.color.gray.main}>
-          {productName}
-        </MediumText>
-        <RegularText size={14} color={theme.color.gray[50]}>
-          마릿수 {quantity} | {isMale ? '수컷' : '암컷'}
-        </RegularText>
-        <FlexBox gap="0.8rem" style={{ width: '100%' }}>
-          {isOnSale && (
-            <>
-              <MediumText size={12} color={theme.color.tint.red}>
-                [{productDiscountRate}%]
-              </MediumText>
-              <RegularText
-                size={14}
-                color={isOnSale ? theme.color.gray[50] : theme.color.gray.main}
-                style={{ textDecoration: 'line-through' }}
-              >
-                {productPrice.toLocaleString()} 원
-              </RegularText>
-            </>
-          )}
-          <MediumText
-            size={18}
-            color={theme.color.gray.main}
-            style={{ marginLeft: 'auto' }}
+      <FlexBox gap="1rem">
+        <ImageBox>
+          <img src={productThumbnailUrl} alt={productName} />
+        </ImageBox>
+        <FlexBox col gap="1.1rem" padding="1.3rem 0" style={{ flex: 1 }}>
+          <FlexBox gap="0.6rem" align="center">
+            <MediumText size={16} color={theme.color.gray.main}>
+              {productName}
+            </MediumText>
+            <DeliveryMethodBox $method={deliveryMethod}>
+              {getKoreanDeliveryMethod(deliveryMethod)}
+            </DeliveryMethodBox>
+          </FlexBox>
+          <RegularText
+            size={12}
+            color={theme.color.gray[50]}
+            style={{ marginTop: '1.3rem' }}
           >
-            {productDiscountPrice.toLocaleString()} 원
-          </MediumText>
+            {quantity}마리 | {sex === 'MALE' ? '수컷' : '암컷'}
+          </RegularText>
+          <FlexBox gap="0.8rem" style={{ width: '100%' }}>
+            {isOnSale && (
+              <>
+                <MediumText size={12} color={theme.color.tint.red}>
+                  [{productDiscountRate}%]
+                </MediumText>
+                <RegularText
+                  size={12}
+                  color={
+                    isOnSale ? theme.color.gray[50] : theme.color.gray.main
+                  }
+                  style={{ textDecoration: 'line-through' }}
+                >
+                  {productPrice.toLocaleString()} 원
+                </RegularText>
+              </>
+            )}
+            <MediumText
+              size={14}
+              color={theme.color.gray.main}
+              style={{ marginLeft: 'auto' }}
+            >
+              {productDiscountPrice.toLocaleString()} 원
+            </MediumText>
+          </FlexBox>
         </FlexBox>
       </FlexBox>
+      {deliveryMethod !== 'PICKUP' && (
+        <PriceInfoContainer>
+          상품금액 {productDiscountPrice.toLocaleString()} 원 +{' '}
+          {getKoreanDeliveryMethod(deliveryMethod)}비{' '}
+          {deliveryFee.toLocaleString()} 원 = {totalPrice.toLocaleString()} 원
+        </PriceInfoContainer>
+      )}
     </Container>
   );
 });

--- a/src/components/organisms/CartFishList.tsx
+++ b/src/components/organisms/CartFishList.tsx
@@ -1,15 +1,15 @@
 import styled from 'styled-components';
 import { BoldText } from '../atoms';
 import { theme } from '../../styles/theme';
-import { CartFish } from '../molecules';
 import { memo } from 'react';
 import { CartItemDetails } from '../../interfaces/payment';
+import { CartFishListByStoreName } from '.';
 
 const Container = styled.div`
-  padding: 2.4rem 1.4rem;
+  padding: 2.4rem 0;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.2rem;
 `;
 
 interface CartFishListProps {
@@ -17,14 +17,43 @@ interface CartFishListProps {
 }
 
 const CartFishList = memo(({ cartData }: CartFishListProps) => {
+  const classifiedByStoreName = cartData.reduce(
+    (acc, item) => {
+      // 현재 아이템의 storeName이 acc 객체에 키로 존재하지 않으면 새 배열을 생성
+      if (!acc[item.storeName]) {
+        acc[item.storeName] = [];
+      }
+
+      // 현재 아이템을 해당 storeName의 배열에 추가
+      acc[item.storeName].push(item);
+
+      return acc;
+    },
+    {} as Record<string, Array<CartItemDetails>>,
+  );
+  const classifiedArray = Object.keys(classifiedByStoreName).map(
+    (storeName) => ({
+      storeName,
+      items: classifiedByStoreName[storeName],
+    }),
+  );
+
   return (
     <Container>
-      <BoldText size={18} color={theme.color.gray.main}>
+      <BoldText
+        size={18}
+        color={theme.color.gray.main}
+        style={{ marginLeft: '1.4rem', marginBottom: '1.2rem' }}
+      >
         어종정보
       </BoldText>
-      {Array.isArray(cartData) &&
-        cartData?.length > 0 &&
-        cartData.map((item) => <CartFish key={item.id} {...item} />)}
+      {classifiedArray.map(({ storeName, items }, idx) => (
+        <CartFishListByStoreName
+          key={idx}
+          storeName={storeName}
+          cartData={items}
+        />
+      ))}
     </Container>
   );
 });

--- a/src/components/organisms/CartFishListByStoreName.tsx
+++ b/src/components/organisms/CartFishListByStoreName.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { CartItemDetails } from '../../interfaces/payment';
+import { CartFish } from '../molecules';
+import { BoldText, FlexBox, MediumText } from '../atoms';
+import { theme } from '../../styles/theme';
+
+const Container = styled.section`
+  background-color: ${({ theme }) => theme.color.blue[10]};
+  padding: 1.8rem 1.2rem 2rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+`;
+
+interface CartFishListByStoreName {
+  storeName: string;
+  cartData: Array<CartItemDetails>;
+}
+
+const CartFishListByStoreName = ({
+  storeName,
+  cartData,
+}: CartFishListByStoreName) => {
+  const totalPaymentPrice = cartData.reduce(
+    (acc, { productDiscountPrice, deliveryFee }) =>
+      acc + productDiscountPrice + deliveryFee,
+    0,
+  );
+  return (
+    <Container>
+      <BoldText size={16} color={theme.color.gray.main}>
+        {storeName}
+      </BoldText>
+      {Array.isArray(cartData) &&
+        cartData?.length > 0 &&
+        cartData.map((item) => <CartFish key={item.id} {...item} />)}
+      <FlexBox gap="1.8rem" align="end" style={{ marginLeft: 'auto' }}>
+        <MediumText size={14} color={theme.color.gray[70]}>
+          총 입양급액
+        </MediumText>
+        <BoldText size={18} color={theme.color.blue[80]}>
+          {totalPaymentPrice.toLocaleString()}원
+        </BoldText>
+      </FlexBox>
+    </Container>
+  );
+};
+
+export default CartFishListByStoreName;

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -15,6 +15,7 @@ import OptionModal from './modals/OptionModal';
 import CartFishList from './CartFishList';
 import CartList from './CartList';
 import ImageDetail from './ImageDetail';
+import CartFishListByStoreName from './CartFishListByStoreName';
 
 export {
   CategoryList,
@@ -34,4 +35,5 @@ export {
   OptionModal,
   CartList,
   ImageDetail,
+  CartFishListByStoreName,
 };

--- a/src/interfaces/payment.ts
+++ b/src/interfaces/payment.ts
@@ -18,7 +18,7 @@ export interface CartItemDetails {
   productDiscountRate: number;
   productDiscountPrice: number;
   quantity: number;
-  sex: string;
+  sex: 'MALE' | 'FEMALE' | 'HERMAPHRODITE';
   deliveryMethod: 'SAFETY' | 'COMMON' | 'PICKUP';
   deliveryFee: number;
   isOnSale: boolean;

--- a/src/interfaces/payment.ts
+++ b/src/interfaces/payment.ts
@@ -18,7 +18,13 @@ export interface CartItemDetails {
   productDiscountRate: number;
   productDiscountPrice: number;
   quantity: number;
-  isMale: boolean;
-  deliveryMethod: string;
+  sex: string;
+  deliveryMethod: 'SAFETY' | 'COMMON' | 'PICKUP';
+  deliveryFee: number;
   isOnSale: boolean;
+  safeDeliveryFee: number;
+  commonDeliveryFee: number;
+  pickUpDeliveryFee: number;
+  maleAdditionalPrice: number;
+  femaleAdditionalPrice: number;
 }

--- a/src/mocks/paymentController.ts
+++ b/src/mocks/paymentController.ts
@@ -46,9 +46,15 @@ export const mockGetCartsAPI = http.get('/api/carts', () => {
       productDiscountRate: 30,
       productDiscountPrice: 21000,
       quantity: 1,
-      isMale: true,
+      sex: 'MALE',
       deliveryMethod: 'SAFETY',
+      deliveryFee: 3000,
       isOnSale: true,
+      safeDeliveryFee: 5000,
+      commonDeliveryFee: 3000,
+      pickUpDeliveryFee: 0,
+      maleAdditionalPrice: 1000,
+      femaleAdditionalPrice: 1000,
     },
   ];
   return HttpResponse.json(data);

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -6,8 +6,12 @@ import { usePaymentStore } from '../states';
 import { CartFishList, DeliveryAddressModal } from '../components/organisms';
 import { CustomHr } from '../components/atoms';
 import { theme } from '../styles/theme';
+import { useParams } from 'react-router-dom';
+import { CartItemDetails } from '../interfaces/payment';
 
 const PaymentPage = () => {
+  const { source } = useParams();
+
   const { address, setAddress } = usePaymentStore();
   const { data: defaultAddressData, isLoading } = useQuery({
     queryKey: ['defaultAddress'],
@@ -21,7 +25,75 @@ const PaymentPage = () => {
     queryFn: getCartsAPI,
     staleTime: 30 * 1000,
     gcTime: 60 * 1000,
+    enabled: source === 'cart',
   });
+
+  // 추후에는 결제 페이지에서 넘어온 데이터 넣는 것으로 수정
+  const MOCK_DATA: CartItemDetails[] = [
+    {
+      id: 1,
+      storeName: '현대올림피아드 아쿠아',
+      productId: 1,
+      productName: '베타',
+      productThumbnailUrl:
+        'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+      productPrice: 30000,
+      productDiscountRate: 30,
+      productDiscountPrice: 21000,
+      quantity: 20,
+      sex: 'FEMALE',
+      deliveryMethod: 'SAFETY',
+      deliveryFee: 10000,
+      isOnSale: true,
+      safeDeliveryFee: 10000,
+      commonDeliveryFee: 3000,
+      pickUpDeliveryFee: 0,
+      maleAdditionalPrice: 1000,
+      femaleAdditionalPrice: 1000,
+    },
+    {
+      id: 2,
+      storeName: '현대올림피아드 아쿠아',
+      productId: 2,
+      productName: '알비노 풀레드 아시안 고정구피',
+      productThumbnailUrl:
+        'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+      productPrice: 30000,
+      productDiscountRate: 30,
+      productDiscountPrice: 21000,
+      quantity: 1,
+      sex: 'MALE',
+      deliveryMethod: 'COMMON',
+      deliveryFee: 3000,
+      isOnSale: true,
+      safeDeliveryFee: 5000,
+      commonDeliveryFee: 3000,
+      pickUpDeliveryFee: 0,
+      maleAdditionalPrice: 1000,
+      femaleAdditionalPrice: 1000,
+    },
+    {
+      id: 3,
+      storeName: 'S아쿠아',
+      productId: 3,
+      productName: '아메리칸 유동구피',
+      productThumbnailUrl:
+        'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+      productPrice: 30000,
+      productDiscountRate: 30,
+      productDiscountPrice: 21000,
+      quantity: 20,
+      sex: 'MALE',
+      deliveryMethod: 'PICKUP',
+      deliveryFee: 0,
+      isOnSale: true,
+      safeDeliveryFee: 5000,
+      commonDeliveryFee: 3000,
+      pickUpDeliveryFee: 0,
+      maleAdditionalPrice: 1000,
+      femaleAdditionalPrice: 1000,
+    },
+  ];
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -39,7 +111,7 @@ const PaymentPage = () => {
       <TopNav backBtn title="주문/결제" />
       {!isLoading && <AddressForm setIsModalOpen={setIsModalOpen} />}
       <CustomHr height="0.8rem" color={theme.color.gray[30]} />
-      <CartFishList cartData={cartData} />
+      <CartFishList cartData={source === 'cart' ? cartData : MOCK_DATA} />
       <CustomHr height="0.8rem" color={theme.color.gray[30]} />
       <PaymentInfo paymentType={paymentType} setPaymentType={setPaymentType} />
       {isModalOpen && (

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -70,7 +70,7 @@ export const router = createBrowserRouter([
         errorElement: <div>Unknown Error</div>,
       },
       {
-        path: '/payment',
+        path: '/payment/:source',
         element: <PaymentPage />,
         errorElement: <div>Unknown Error</div>,
         loader: authorizedLoader,

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -10,6 +10,7 @@ interface Font {
   bold16: RuleSet<object>;
   bold14: RuleSet<object>;
   bold12: RuleSet<object>;
+  bold10: RuleSet<object>;
   medium28: RuleSet<object>;
   medium24: RuleSet<object>;
   medium20: RuleSet<object>;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -45,6 +45,11 @@ const bold12 = css`
   font-weight: 700;
 `;
 
+const bold10 = css`
+  font-size: 1rem;
+  font-weight: 700;
+`;
+
 const medium28 = css`
   font-size: 2.8rem;
   font-weight: 500;
@@ -172,6 +177,7 @@ const font = {
   bold16,
   bold14,
   bold12,
+  bold10,
   medium28,
   medium24,
   medium20,

--- a/src/utils/payment.ts
+++ b/src/utils/payment.ts
@@ -1,0 +1,39 @@
+import { theme } from '../styles/theme';
+
+export const getKoreanDeliveryMethod = (method: string) => {
+  switch (method) {
+    case 'COMMON':
+      return '일반운송';
+    case 'SAFETY':
+      return '안전운송';
+    case 'PICKUP':
+      return '직접방문';
+    default:
+      return method;
+  }
+};
+
+export const getBackgroundColor = (method: string) => {
+  switch (method) {
+    case 'SAFETY':
+      return theme.color.blue[80];
+    case 'COMMON':
+      return theme.color.gray[40];
+    case 'PICKUP':
+      return theme.color.gray.main;
+    default:
+      return 'white';
+  }
+};
+
+export const getTextColor = (method: string) => {
+  switch (method) {
+    case 'SAFETY':
+    case 'PICKUP':
+      return theme.color.tint.white;
+    case 'COMMON':
+      return theme.color.gray.main;
+    default:
+      return 'black';
+  }
+};

--- a/src/utils/payment.ts
+++ b/src/utils/payment.ts
@@ -13,6 +13,19 @@ export const getKoreanDeliveryMethod = (method: string) => {
   }
 };
 
+export const getSex = (sex: string) => {
+  switch (sex) {
+    case 'MALE':
+      return '수컷';
+    case 'FEMALE':
+      return '암컷';
+    case 'HERMAPHRODITE':
+      return '자웅동체';
+    default:
+      return sex;
+  }
+};
+
 export const getBackgroundColor = (method: string) => {
   switch (method) {
     case 'SAFETY':


### PR DESCRIPTION
> Close #115 

## Preview
https://frontend-git-115-blueapple99s-projects.vercel.app/

## 사진
![image](https://github.com/petqua/frontend/assets/87417773/960f39cd-c821-4d3f-bc7d-cc7ccced11b0)

## 커밋 리스트

#### ✅ chore: 폰트 추가

- bold10 추가

#### ✅ feat: 결제 페이지 경로 변경

- 결제 경로에 소스 식별자를 도입하여 다양한 결제 소스를 지원
- 서버에서 받아오는 data 양식 수정

#### ✅ feat: storeName으로 구분하는 컴포넌트 추가

- storeName 별로 영역 분리 및 총 입양 금액 계산


#### ✅ feat: 결제 어종 정보 수정 사항 반영

- CartFishList에서 CartFish를 render하지 않고 CartFishListByStoreName을 render
- CartFish 운송방식 알려주는 태그 추가
- CartFish 운송비를 포함한 가격 안내하는 태그 추가

## Comment

- 이미 했던 작업에 디자인이 바꾸는 경우가 참 많다라는 생각이 드네요.
