### PR TITLE
[#119] 결제 금액 컴포넌트 구현

### DIFF
--- a/src/components/atoms/CustomHr.tsx
+++ b/src/components/atoms/CustomHr.tsx
@@ -9,10 +9,11 @@ const Hr = styled.hr<{ $height: string; $color: string }>`
 interface CustomHr {
   height: string;
   color: string;
+  style?: any;
 }
 
-const CustomHr = ({ height, color }: CustomHr) => {
-  return <Hr $height={height} $color={color} />;
+const CustomHr = ({ height, color, style }: CustomHr) => {
+  return <Hr $height={height} $color={color} style={{ ...style }} />;
 };
 
 export default CustomHr;

--- a/src/components/molecules/CartFish.tsx
+++ b/src/components/molecules/CartFish.tsx
@@ -8,7 +8,7 @@ import {
   getKoreanDeliveryMethod,
   getSex,
   getTextColor,
-} from '../../utils/payment';
+} from '../../utils/delivery';
 
 const Container = styled.div`
   padding: 1rem 1.7rem;

--- a/src/components/molecules/PaymentInfo.tsx
+++ b/src/components/molecules/PaymentInfo.tsx
@@ -52,7 +52,7 @@ const PaymentInfo = ({ paymentType, setPaymentType }: PaymentInfo) => {
   return (
     <Container>
       <BoldText size={18} color={theme.color.gray.main}>
-        결제정보
+        결제 정보
       </BoldText>
       <GridBox>
         {PAYMENT_TYPE.map((payment_type, idx) => (

--- a/src/components/molecules/PaymentSummary.tsx
+++ b/src/components/molecules/PaymentSummary.tsx
@@ -1,0 +1,118 @@
+import styled from 'styled-components';
+import { theme } from '../../styles/theme';
+import { BoldText, CustomHr, FlexBox, RegularText } from '../atoms';
+import { TotalFee } from '../../interfaces/payment';
+import { getTotalDeliveryFee } from '../../utils/delivery';
+import {
+  IoChevronDownCircleSharp,
+  IoChevronUpCircleSharp,
+} from 'react-icons/io5';
+import { memo, useState } from 'react';
+
+const Container = styled.section`
+  padding: 2.4rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;
+
+interface PaymentSummary {
+  totalFee: TotalFee;
+}
+
+const PaymentSummary = memo(({ totalFee }: PaymentSummary) => {
+  const { totalAdoptionFee, totalCommonDeliveryFee, totalSafeDeliveryFee } =
+    totalFee;
+
+  // 운송비 버튼 토글 로직
+  const [isToggled, setIsToggled] = useState(false);
+
+  const toggleIcon = () => {
+    setIsToggled(!isToggled);
+  };
+
+  return (
+    <Container>
+      <BoldText
+        size={18}
+        color={theme.color.gray.main}
+        style={{ marginBottom: '0.4rem' }}
+      >
+        결제 금액
+      </BoldText>
+      <FlexBox justify="space-between">
+        <RegularText size={14} color={theme.color.gray[50]}>
+          총 입양 금액
+        </RegularText>
+        <RegularText size={14} color={theme.color.gray[70]}>
+          {totalAdoptionFee.toLocaleString()} 원
+        </RegularText>
+      </FlexBox>
+      <FlexBox justify="space-between">
+        <RegularText size={14} color={theme.color.gray[50]}>
+          할인 금액
+        </RegularText>
+        <RegularText size={14} color={theme.color.gray[70]}>
+          0 원
+        </RegularText>
+      </FlexBox>
+      <FlexBox gap="0.8rem" align="center">
+        <RegularText size={14} color={theme.color.gray[50]}>
+          운송비
+        </RegularText>
+        <button onClick={toggleIcon}>
+          {isToggled ? (
+            <IoChevronUpCircleSharp size={16} color={theme.color.gray[60]} />
+          ) : (
+            <IoChevronDownCircleSharp size={16} color={theme.color.gray[60]} />
+          )}
+        </button>
+        <RegularText
+          size={14}
+          color={theme.color.gray[70]}
+          style={{ marginLeft: 'auto' }}
+        >
+          {getTotalDeliveryFee(totalFee).toLocaleString()} 원
+        </RegularText>
+      </FlexBox>
+      {isToggled && (
+        <FlexBox col gap="0.6rem">
+          <FlexBox>
+            <RegularText size={12} color={theme.color.gray[50]}>
+              • 일반 운송 &nbsp;&nbsp;-----------&nbsp;&nbsp; +
+              {totalCommonDeliveryFee.toLocaleString()}
+            </RegularText>
+          </FlexBox>
+          <FlexBox>
+            <RegularText size={12} color={theme.color.gray[50]}>
+              • 안전 운송 &nbsp;&nbsp;-----------&nbsp;&nbsp; +
+              {totalSafeDeliveryFee.toLocaleString()}
+            </RegularText>
+          </FlexBox>
+          <FlexBox>
+            <RegularText size={12} color={theme.color.gray[50]}>
+              • 매장 픽업 &nbsp;&nbsp;-----------&nbsp;&nbsp; + 무료
+            </RegularText>
+          </FlexBox>
+        </FlexBox>
+      )}
+      <CustomHr
+        height="0.1rem"
+        color={theme.color.gray[50]}
+        style={{ marginTop: '0.4rem', marginBottom: '1.6rem' }}
+      />
+      <FlexBox justify="space-between">
+        <BoldText size={18} color={theme.color.gray.main}>
+          최종 결제 금액
+        </BoldText>
+        <BoldText size={18} color={theme.color.blue[80]}>
+          {totalAdoptionFee.toLocaleString()} 원
+        </BoldText>
+      </FlexBox>
+    </Container>
+  );
+});
+
+PaymentSummary.displayName = 'PaymentSummary';
+
+export default PaymentSummary;

--- a/src/components/molecules/PaymentSummary.tsx
+++ b/src/components/molecules/PaymentSummary.tsx
@@ -77,23 +77,14 @@ const PaymentSummary = memo(({ totalFee }: PaymentSummary) => {
       </FlexBox>
       {isToggled && (
         <FlexBox col gap="0.6rem">
-          <FlexBox>
-            <RegularText size={12} color={theme.color.gray[50]}>
-              • 일반 운송 &nbsp;&nbsp;-----------&nbsp;&nbsp; +
-              {totalCommonDeliveryFee.toLocaleString()}
-            </RegularText>
-          </FlexBox>
-          <FlexBox>
-            <RegularText size={12} color={theme.color.gray[50]}>
-              • 안전 운송 &nbsp;&nbsp;-----------&nbsp;&nbsp; +
-              {totalSafeDeliveryFee.toLocaleString()}
-            </RegularText>
-          </FlexBox>
-          <FlexBox>
-            <RegularText size={12} color={theme.color.gray[50]}>
-              • 매장 픽업 &nbsp;&nbsp;-----------&nbsp;&nbsp; + 무료
-            </RegularText>
-          </FlexBox>
+          <RegularText size={12} color={theme.color.gray[50]}>
+            • 일반 운송 &nbsp;&nbsp;-----------&nbsp;&nbsp; +
+            {totalCommonDeliveryFee.toLocaleString()}
+          </RegularText>
+          <RegularText size={12} color={theme.color.gray[50]}>
+            • 안전 운송 &nbsp;&nbsp;-----------&nbsp;&nbsp; +
+            {totalSafeDeliveryFee.toLocaleString()}
+          </RegularText>
         </FlexBox>
       )}
       <CustomHr

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -24,6 +24,7 @@ import PopUp from './PopUp';
 import Confirm from './Confirm';
 import CartItem from './CartItem';
 import PaymentInfo from './PaymentInfo';
+import PaymentSummary from './PaymentSummary';
 
 export {
   ProductListItem,
@@ -52,4 +53,5 @@ export {
   Confirm,
   CartItem,
   PaymentInfo,
+  PaymentSummary,
 };

--- a/src/components/organisms/CartFishList.tsx
+++ b/src/components/organisms/CartFishList.tsx
@@ -45,7 +45,7 @@ const CartFishList = memo(({ cartData }: CartFishListProps) => {
         color={theme.color.gray.main}
         style={{ marginLeft: '1.4rem', marginBottom: '1.2rem' }}
       >
-        어종정보
+        어종 정보
       </BoldText>
       {classifiedArray.map(({ storeName, items }, idx) => (
         <CartFishListByStoreName

--- a/src/components/organisms/CartFishListByStoreName.tsx
+++ b/src/components/organisms/CartFishListByStoreName.tsx
@@ -36,7 +36,7 @@ const CartFishListByStoreName = ({
         cartData.map((item) => <CartFish key={item.id} {...item} />)}
       <FlexBox gap="1.8rem" align="end" style={{ marginLeft: 'auto' }}>
         <MediumText size={14} color={theme.color.gray[70]}>
-          총 입양급액
+          총 입양 금액
         </MediumText>
         <BoldText size={18} color={theme.color.blue[80]}>
           {totalPaymentPrice.toLocaleString()}원

--- a/src/interfaces/payment.ts
+++ b/src/interfaces/payment.ts
@@ -28,3 +28,10 @@ export interface CartItemDetails {
   maleAdditionalPrice: number;
   femaleAdditionalPrice: number;
 }
+
+export interface TotalFee {
+  totalAdoptionFee: number;
+  totalSafeDeliveryFee: number;
+  totalCommonDeliveryFee: number;
+  totalPickUpDeliveryFee: number;
+}

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -1,13 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
-import { AddressForm, PaymentInfo, TopNav } from '../components/molecules';
+import {
+  AddressForm,
+  PaymentInfo,
+  PaymentSummary,
+  TopNav,
+} from '../components/molecules';
 import { getCartsAPI, getDefaultAddressAPI } from '../apis';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { usePaymentStore } from '../states';
 import { CartFishList, DeliveryAddressModal } from '../components/organisms';
 import { CustomHr } from '../components/atoms';
 import { theme } from '../styles/theme';
 import { useParams } from 'react-router-dom';
 import { CartItemDetails } from '../interfaces/payment';
+import { getTotalFee } from '../utils/delivery';
 
 const PaymentPage = () => {
   const { source } = useParams();
@@ -98,6 +104,8 @@ const PaymentPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const [paymentType, setPaymentType] = useState('신용/체크카드');
+  // 지금은 그냥 MOCK_DATA로 테스트, 추후에 source에 따라서 cartData 또는 directData 로 변경
+  const totalFee = useMemo(() => getTotalFee(MOCK_DATA), [MOCK_DATA]);
 
   useEffect(() => {
     if (address !== null) return;
@@ -114,6 +122,8 @@ const PaymentPage = () => {
       <CartFishList cartData={source === 'cart' ? cartData : MOCK_DATA} />
       <CustomHr height="0.8rem" color={theme.color.gray[30]} />
       <PaymentInfo paymentType={paymentType} setPaymentType={setPaymentType} />
+      <CustomHr height="0.8rem" color={theme.color.gray[30]} />
+      <PaymentSummary totalFee={totalFee} />
       {isModalOpen && (
         <DeliveryAddressModal
           title="운송지 추가"

--- a/src/utils/delivery.ts
+++ b/src/utils/delivery.ts
@@ -1,3 +1,4 @@
+import { CartItemDetails, TotalFee } from '../interfaces/payment';
 import { theme } from '../styles/theme';
 
 export const getKoreanDeliveryMethod = (method: string) => {
@@ -49,4 +50,34 @@ export const getTextColor = (method: string) => {
     default:
       return 'black';
   }
+};
+
+export const getTotalFee = (data: Array<CartItemDetails>) => {
+  return data.reduce(
+    (acc, { productDiscountPrice, deliveryFee, deliveryMethod }) => {
+      acc.totalAdoptionFee += productDiscountPrice + deliveryFee;
+      if (deliveryMethod === 'SAFETY') {
+        acc.totalSafeDeliveryFee += deliveryFee;
+      } else if (deliveryMethod === 'COMMON') {
+        acc.totalCommonDeliveryFee += deliveryFee;
+      } else {
+        acc.totalPickUpDeliveryFee += deliveryFee;
+      }
+      return acc;
+    },
+    {
+      totalAdoptionFee: 0,
+      totalSafeDeliveryFee: 0,
+      totalCommonDeliveryFee: 0,
+      totalPickUpDeliveryFee: 0,
+    },
+  );
+};
+
+export const getTotalDeliveryFee = (totalFee: TotalFee) => {
+  return (
+    totalFee.totalCommonDeliveryFee +
+    totalFee.totalSafeDeliveryFee +
+    totalFee.totalPickUpDeliveryFee
+  );
 };


### PR DESCRIPTION
> Close #119 

## Preview
https://frontend-git-119-blueapple99s-projects.vercel.app/

## 사진
![image](https://github.com/petqua/frontend/assets/87417773/3e6961e6-8990-4c11-98d8-d05596bc5dc0)

## React.memo, useMemo
결제 페이지에서 결제할 상품들의 데이터를 순회하며 계산한 결과인 totalFee를 결제 금액 컴포넌트에게 props로 넘기게 됩니다.

### useMemo 적용한 이유
- 계산 비용이 어느 정도 있다.
- 의존성 배열의 값이 자주 변경되지 않는다.

### React.memo 적용한 이유
- props가 자주 변경되지 않는다.
- 부모 컴포넌트에 다수의 자식 컴포넌트가 존재한다.

## 커밋 리스트

#### ✅ refactor: 기존 컴포넌트 리팩토링

- 띄어쓰기 추가
- 오타 수정

#### ✅ feat: 결제 금액 컴포넌트 구현

- 운송비 버튼 토글 기능 구현
- TotalFee interface 추가
- props로 넘어오는 값 useMemo 적용 -> props 받은 컴포넌트 React.memo 적용