### PR TITLE
[#116] 봉달목록 레이아웃 디자인 변경

### DIFF
--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -1,0 +1,59 @@
+import { styled } from 'styled-components';
+import { theme } from '../../styles/theme';
+import { FaCheck } from 'react-icons/fa6';
+
+interface CheckBox {
+  checked: boolean;
+  onChange: (e?: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const CheckBox = ({ checked, onChange }: CheckBox) => {
+  return (
+    <Container checked={checked}>
+      <input type="checkbox" checked={checked} onChange={onChange} />
+      <div>
+        <FaCheck
+          size={12}
+          color={theme.color.tint.white}
+          style={{
+            visibility: checked ? 'visible' : 'hidden',
+          }}
+        />
+      </div>
+    </Container>
+  );
+};
+
+export default CheckBox;
+
+const Container = styled.label<{ checked: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  cursor: pointer;
+
+  input {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    border: ${({ checked, theme }) =>
+      checked ? 'none' : `solid 0.1rem ${theme.color.gray[50]}`};
+    background: ${({ checked, theme }) =>
+      checked ? theme.color.blue[80] : 'white'};
+  }
+`;

--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -33,15 +33,7 @@ const Container = styled.label<{ checked: boolean }>`
   cursor: pointer;
 
   input {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
+    display: none;
   }
 
   div {

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -4,6 +4,7 @@ import KeywordText from './KeywordText';
 import ProductImg from './ProductImg';
 import ProfileImg from './ProfileImg';
 import { LightText, RegularText, MediumText, BoldText } from './Text';
+import CheckBox from './Checkbox';
 
 export {
   FlexBox,
@@ -15,4 +16,5 @@ export {
   KeywordText,
   CustomHr,
   ProfileImg,
+  CheckBox,
 };

--- a/src/components/molecules/CartItem.tsx
+++ b/src/components/molecules/CartItem.tsx
@@ -6,94 +6,132 @@ import { OptionModal } from '../organisms';
 import Confirm from './Confirm';
 import { LiaWindowClose } from 'react-icons/lia';
 import { FaCheck } from 'react-icons/fa6';
+import { CartItem } from '../../interfaces/cart';
 
-const CartItem = ({ data }: { data: any }) => {
+const CartItem = ({ data, handleSelectItem }: CartItem) => {
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [isOpenConfirm, setIsOpenConfirm] = useState(false);
-  const [checked, setChecked] = useState(true);
+
+  const getMethod = (method: string) => {
+    if (method === 'COMMON') return '일반운송';
+    if (method === 'SAFETY') return '안전운송';
+    if (method === 'PICKUP') return '직접픽업';
+    return 'error';
+  };
+
+  const getSex = (sex: string) => {
+    if (sex === 'MALE') return '수컷';
+    if (sex === 'FEMALE') return '암컷';
+    if (sex === 'PICKUP') return '자웅동체';
+    return 'error';
+  };
 
   return (
     <>
-      <FlexBox padding="1.2rem 0" gap="0.6rem" fullWidth>
-        <CheckBox checked={checked}>
+      <Container>
+        <CheckBox checked={data?.checked}>
           <input
             type="checkbox"
-            checked={checked}
-            onChange={(e) => setChecked(e.currentTarget.checked)}
+            checked={data?.checked}
+            onChange={(e) =>
+              handleSelectItem(
+                data?.storeName,
+                data?.id,
+                e.currentTarget.checked,
+              )
+            }
           />
           <div>
             <FaCheck
               size={12}
               color={theme.color.tint.white}
               style={{
-                visibility: checked ? 'visible' : 'hidden',
+                visibility: data?.checked ? 'visible' : 'hidden',
               }}
             />
           </div>
         </CheckBox>
-        <FlexBox gap="1.2rem" align="center" style={{ flex: 1 }}>
-          <ProductImg size="9rem" src={data?.productThumbnailUrl} />
-          <FlexBox
-            col
-            justify="space-between"
-            style={{ flex: 1, minHeight: '9rem' }}
-          >
-            <FlexBox justify="space-between" fullWidth>
-              <FlexBox col gap="0.4rem" style={{ flex: 1 }}>
-                <RegularText size={12} color={theme.color.gray[50]}>
-                  {data?.storeName}
-                </RegularText>
-                <MediumText
-                  size={16}
-                  color={theme.color.gray.main}
-                  style={{ lineHeight: '120%' }}
-                >
-                  {data?.productName}
-                </MediumText>
-              </FlexBox>
-              <LiaWindowClose
-                size={18}
-                color={theme.color.gray[50]}
-                style={{ cursor: 'pointer' }}
-                onClick={() => setIsOpenConfirm(true)}
-              />
-            </FlexBox>
-
-            <FlexBox col gap="0.8rem" fullWidth>
-              <FlexBox justify="space-between" align="center" fullWidth>
-                <RegularText size={12} color={theme.color.gray[50]}>
-                  마릿수 {data?.quantity} | {data?.isMale ? '수컷' : '암컷'}
-                </RegularText>
-                {data?.productDiscountRate && (
-                  <FlexBox align="center" gap="0.4rem">
-                    <MediumText size={12} color={theme.color.tint.red}>
-                      [{data?.productDiscountRate}%]
-                    </MediumText>
-                    <RegularText
-                      size={12}
-                      color={theme.color.gray[50]}
-                      style={{ textDecoration: 'line-through' }}
-                    >
-                      {data?.productPrice.toLocaleString()} 원
-                    </RegularText>
-                  </FlexBox>
-                )}
+        <FlexBox col gap="1.6rem" style={{ flex: 1 }}>
+          <FlexBox gap="1rem" align="center" fullWidth>
+            <ProductImg size="9.6rem" src={''} />
+            <FlexBox
+              col
+              justify="space-between"
+              style={{ flex: 1, minHeight: '9rem' }}
+            >
+              <FlexBox justify="space-between" fullWidth>
+                <FlexBox col gap="0.4rem" style={{ flex: 1 }}>
+                  <MediumText
+                    size={16}
+                    color={theme.color.gray.main}
+                    style={{ lineHeight: '120%' }}
+                  >
+                    {data?.productName}
+                    <MethodTag $method={data?.deliveryMethod}>
+                      {getMethod(data?.deliveryMethod)}
+                    </MethodTag>
+                  </MediumText>
+                </FlexBox>
+                <LiaWindowClose
+                  size={18}
+                  color={theme.color.gray[50]}
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => setIsOpenConfirm(true)}
+                />
               </FlexBox>
 
-              <FlexBox justify="space-between" align="center" fullWidth>
-                <OptionButton onClick={() => setIsOpenModal(true)}>
+              <FlexBox col gap="0.8rem" fullWidth>
+                <FlexBox justify="space-between" align="center" fullWidth>
                   <RegularText size={12} color={theme.color.gray[50]}>
-                    옵션변경
+                    {data?.quantity}마리 | {getSex(data?.sex)}
                   </RegularText>
-                </OptionButton>
-                <MediumText size={18} color={theme.color.gray.main}>
-                  {data?.productDiscountPrice.toLocaleString()} 원
-                </MediumText>
+                  {data?.productDiscountRate && (
+                    <FlexBox align="center" gap="0.4rem">
+                      <MediumText size={12} color={theme.color.tint.red}>
+                        [{data?.productDiscountRate}%]
+                      </MediumText>
+                      <RegularText
+                        size={12}
+                        color={theme.color.gray[50]}
+                        style={{ textDecoration: 'line-through' }}
+                      >
+                        {data?.productPrice.toLocaleString()} 원
+                      </RegularText>
+                    </FlexBox>
+                  )}
+                </FlexBox>
+
+                <FlexBox justify="space-between" align="center" fullWidth>
+                  <OptionButton onClick={() => setIsOpenModal(true)}>
+                    <RegularText size={12} color={theme.color.gray[50]}>
+                      옵션변경
+                    </RegularText>
+                  </OptionButton>
+                  <MediumText size={14} color={theme.color.gray.main}>
+                    {data?.productDiscountPrice.toLocaleString()} 원
+                  </MediumText>
+                </FlexBox>
               </FlexBox>
             </FlexBox>
           </FlexBox>
+          {data?.deliveryMethod !== 'PICKUP' && (
+            <PriceCalculatorBox>
+              <MediumText
+                size={12}
+                color={theme.color.blue[70]}
+                style={{ textAlign: 'center' }}
+              >
+                {`상품금액 ${data?.productDiscountPrice.toLocaleString()} + 
+              ${getMethod(data?.deliveryMethod)}비 
+              ${data?.deliveryFee.toLocaleString()} = 
+              ${(
+                data?.productDiscountPrice + data?.deliveryFee
+              ).toLocaleString()}`}
+              </MediumText>
+            </PriceCalculatorBox>
+          )}
         </FlexBox>
-      </FlexBox>
+      </Container>
       {isOpenModal && <OptionModal setIsOpenModal={setIsOpenModal} />}
       {isOpenConfirm && (
         <Confirm
@@ -107,6 +145,16 @@ const CartItem = ({ data }: { data: any }) => {
 };
 
 export default CartItem;
+
+const Container = styled.section`
+  display: flex;
+  align-items: flex-start;
+  padding: 1rem 0.8rem;
+  gap: 0.6rem;
+  width: 100%;
+  background-color: white;
+  border-radius: 1.2rem;
+`;
 
 const OptionButton = styled.button`
   padding: 0.4rem 0.6rem;
@@ -144,4 +192,31 @@ const CheckBox = styled.label<{ checked: boolean }>`
     background: ${({ checked, theme }) =>
       checked ? theme.color.blue[80] : 'white'};
   }
+`;
+
+const MethodTag = styled.div<{ $method: string }>`
+  padding: 0.3rem 0.6rem;
+  border-radius: 0.6rem;
+  background-color: ${({ $method, theme }) =>
+    $method === 'COMMON'
+      ? theme.color.gray[40]
+      : $method === 'SAFETY'
+        ? theme.color.blue[80]
+        : theme.color.gray.main};
+  color: ${({ $method, theme }) =>
+    $method === 'COMMON' ? theme.color.gray.main : theme.color.tint.white};
+  font-size: 1rem;
+  font-weight: 700;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.4rem;
+  line-height: 1;
+  margin-bottom: 0.2rem;
+`;
+
+const PriceCalculatorBox = styled.div`
+  width: 100%;
+  border-radius: 3rem;
+  border: 0.05rem solid ${({ theme }) => theme.color.blue[70]};
+  padding: 0.6rem;
 `;

--- a/src/components/molecules/CartItem.tsx
+++ b/src/components/molecules/CartItem.tsx
@@ -1,56 +1,57 @@
 import { useState } from 'react';
 import { styled } from 'styled-components';
 import { theme } from '../../styles/theme';
-import { FlexBox, MediumText, RegularText, ProductImg } from '../atoms';
+import {
+  FlexBox,
+  MediumText,
+  RegularText,
+  ProductImg,
+  CheckBox,
+} from '../atoms';
 import { OptionModal } from '../organisms';
 import Confirm from './Confirm';
 import { LiaWindowClose } from 'react-icons/lia';
-import { FaCheck } from 'react-icons/fa6';
 import { CartItem } from '../../interfaces/cart';
+import {
+  getKoreanDeliveryMethod,
+  getSex,
+  getBackgroundColor,
+  getTextColor,
+} from '../../utils/delivery';
 
 const CartItem = ({ data, handleSelectItem }: CartItem) => {
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [isOpenConfirm, setIsOpenConfirm] = useState(false);
-
-  const getMethod = (method: string) => {
-    if (method === 'COMMON') return '일반운송';
-    if (method === 'SAFETY') return '안전운송';
-    if (method === 'PICKUP') return '직접픽업';
-    return 'error';
-  };
-
-  const getSex = (sex: string) => {
-    if (sex === 'MALE') return '수컷';
-    if (sex === 'FEMALE') return '암컷';
-    if (sex === 'PICKUP') return '자웅동체';
-    return 'error';
-  };
+  // const {
+  //   safeDeliveryFee,
+  //   commonDeliveryFee,
+  //   pickUpDeliveryFee,
+  //   maleAdditionalPrice,
+  //   femaleAdditionalPrice,
+  //   quantity,
+  // } = data;
+  // const optionData = {
+  //   safeDeliveryFee,
+  //   commonDeliveryFee,
+  //   pickUpDeliveryFee,
+  //   maleAdditionalPrice,
+  //   femaleAdditionalPrice,
+  //   quantity,
+  // };
 
   return (
     <>
       <Container>
-        <CheckBox checked={data?.checked}>
-          <input
-            type="checkbox"
-            checked={data?.checked}
-            onChange={(e) =>
-              handleSelectItem(
-                data?.storeName,
-                data?.id,
-                e.currentTarget.checked,
-              )
-            }
-          />
-          <div>
-            <FaCheck
-              size={12}
-              color={theme.color.tint.white}
-              style={{
-                visibility: data?.checked ? 'visible' : 'hidden',
-              }}
-            />
-          </div>
-        </CheckBox>
+        <CheckBox
+          checked={data?.checked}
+          onChange={(e) =>
+            handleSelectItem(
+              data?.storeName,
+              data?.id,
+              e?.currentTarget.checked || false,
+            )
+          }
+        />
         <FlexBox col gap="1.6rem" style={{ flex: 1 }}>
           <FlexBox gap="1rem" align="center" fullWidth>
             <ProductImg size="9.6rem" src={''} />
@@ -68,7 +69,7 @@ const CartItem = ({ data, handleSelectItem }: CartItem) => {
                   >
                     {data?.productName}
                     <MethodTag $method={data?.deliveryMethod}>
-                      {getMethod(data?.deliveryMethod)}
+                      {getKoreanDeliveryMethod(data?.deliveryMethod)}
                     </MethodTag>
                   </MediumText>
                 </FlexBox>
@@ -122,7 +123,7 @@ const CartItem = ({ data, handleSelectItem }: CartItem) => {
                 style={{ textAlign: 'center' }}
               >
                 {`상품금액 ${data?.productDiscountPrice.toLocaleString()} + 
-              ${getMethod(data?.deliveryMethod)}비 
+              ${getKoreanDeliveryMethod(data?.deliveryMethod)}비 
               ${data?.deliveryFee.toLocaleString()} = 
               ${(
                 data?.productDiscountPrice + data?.deliveryFee
@@ -162,49 +163,11 @@ const OptionButton = styled.button`
   border: 0.05rem solid ${({ theme }) => theme.color.gray[50]};
 `;
 
-const CheckBox = styled.label<{ checked: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  cursor: pointer;
-
-  input {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
-
-  div {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 50%;
-    border: ${({ checked, theme }) =>
-      checked ? 'none' : `solid 0.1rem ${theme.color.gray[50]}`};
-    background: ${({ checked, theme }) =>
-      checked ? theme.color.blue[80] : 'white'};
-  }
-`;
-
 const MethodTag = styled.div<{ $method: string }>`
   padding: 0.3rem 0.6rem;
   border-radius: 0.6rem;
-  background-color: ${({ $method, theme }) =>
-    $method === 'COMMON'
-      ? theme.color.gray[40]
-      : $method === 'SAFETY'
-        ? theme.color.blue[80]
-        : theme.color.gray.main};
-  color: ${({ $method, theme }) =>
-    $method === 'COMMON' ? theme.color.gray.main : theme.color.tint.white};
+  background-color: ${({ $method }) => getBackgroundColor($method)};
+  color: ${({ $method }) => getTextColor($method)};
   font-size: 1rem;
   font-weight: 700;
   display: inline-block;

--- a/src/components/molecules/CartStoreSection.tsx
+++ b/src/components/molecules/CartStoreSection.tsx
@@ -1,0 +1,58 @@
+import { styled } from 'styled-components';
+import { theme } from '../../styles/theme';
+import { BoldText, MediumText, FlexBox, CheckBox } from '../atoms';
+import { CartItem } from '../molecules';
+import { CartStoreSection } from '../../interfaces/cart';
+
+const CartStoreSection = ({
+  data,
+  handleSelectStore,
+  handleSelectItem,
+}: CartStoreSection) => {
+  const checkedItemsPrice = data.items.reduce((total, item) => {
+    return (
+      total + (item.checked ? item.productDiscountPrice + item.deliveryFee : 0)
+    );
+  }, 0);
+
+  return (
+    <Container>
+      <FlexBox align="center" gap="1rem" padding="0 0.8rem">
+        <CheckBox
+          checked={data?.checked}
+          onChange={(e) =>
+            handleSelectStore(data.storeName, e?.currentTarget.checked || false)
+          }
+        />
+
+        <BoldText size={16} color={theme.color.gray.main}>
+          {data.storeName}
+        </BoldText>
+      </FlexBox>
+      {data.items?.map((item: any, idx: number) => (
+        <CartItem key={idx} data={item} handleSelectItem={handleSelectItem} />
+      ))}
+      <FlexBox justify="flex-end" align="center" gap="1.8rem" fullWidth>
+        <MediumText size={14} color={theme.color.gray[70]}>
+          총 입양금액
+        </MediumText>
+        <BoldText size={18} color={theme.color.blue[80]}>
+          {checkedItemsPrice.toLocaleString()}원
+        </BoldText>
+      </FlexBox>
+    </Container>
+  );
+};
+
+export default CartStoreSection;
+
+const Container = styled.section`
+  width: calc(100% - 1.6rem);
+  margin: 0 0.8rem;
+  display: flex;
+  flex-direction: column;
+  padding: 2.4rem 0.6rem;
+  gap: 1.8rem;
+  border-radius: 1.4rem;
+  background: ${({ theme }) => theme.color.blue[10]};
+`;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -23,6 +23,7 @@ import ReviewItem from './ReviewItem';
 import PopUp from './PopUp';
 import Confirm from './Confirm';
 import CartItem from './CartItem';
+import CartStoreSection from './CartStoreSection';
 
 export {
   ProductListItem,
@@ -50,4 +51,5 @@ export {
   PopUp,
   Confirm,
   CartItem,
+  CartStoreSection,
 };

--- a/src/components/organisms/CartList.tsx
+++ b/src/components/organisms/CartList.tsx
@@ -1,160 +1,205 @@
-// import { useState } from 'react';
 import { styled } from 'styled-components';
 import { theme } from '../../styles/theme';
-import { BoldText, MediumText, FlexBox } from '../atoms';
-import { CartItem } from '../molecules';
+import { BoldText, MediumText, FlexBox, RegularText, CheckBox } from '../atoms';
 import { useState } from 'react';
-import { FaCheck } from 'react-icons/fa6';
+import { IoIosArrowDown } from 'react-icons/io';
+import { CartList } from '../../interfaces/cart';
+import { CartStoreSection } from '../molecules';
 
-interface CartCategory {
-  listData?: any[];
-  method: string;
-}
+const CartList = ({ data, setData, checkedItemData }: CartList) => {
+  const {
+    totalCount,
+    totalOriginalPrice,
+    totalDiscountedPrices,
+    totalCommonDeliveryFees,
+    totalSafetyDeliveryFees,
+  } = checkedItemData;
+  const [isOpenToggle, setIsOpenToggle] = useState(true);
+  const totalItemCount = data.reduce(
+    (total, store) => total + store.items.length,
+    0,
+  );
 
-const CartCategory = ({ listData, method }: CartCategory) => {
-  const getTitle = (method: string) => {
-    if (method === 'COMMON') return '일반운송';
-    if (method === 'SAFETY') return '안전운송';
-    if (method === 'PICKUP') return '직접픽업';
-    return 'error';
+  // 체크박스 선택 기능
+  const [selectAll, setSelectAll] = useState(true);
+
+  const handleSelectAll = () => {
+    const newData = data.map((store) => ({
+      ...store,
+      checked: !selectAll,
+      items: store.items.map((item) => ({
+        ...item,
+        checked: !selectAll,
+      })),
+    }));
+
+    setSelectAll(!selectAll);
+    setData(newData);
+  };
+
+  const handleSelectStore = (storeName: string, value: boolean) => {
+    const newData = data.map((store) =>
+      store.storeName === storeName
+        ? {
+            ...store,
+            items: store.items.map((item) => ({ ...item, checked: value })),
+            checked: value,
+          }
+        : store,
+    );
+
+    setSelectAll(newData.every((item) => item.checked));
+    setData(newData);
+  };
+
+  const handleSelectItem = (
+    storeName: string,
+    itemId: number,
+    value: boolean,
+  ) => {
+    const newData = [...data];
+    const storeIndex = newData.findIndex(
+      (store) => store.storeName === storeName,
+    );
+    if (storeIndex !== -1) {
+      const itemIndex = newData[storeIndex].items.findIndex(
+        (item) => item.id === itemId,
+      );
+      if (itemIndex !== -1) {
+        newData[storeIndex].items[itemIndex].checked = value;
+
+        const allItemsChecked = newData[storeIndex].items.every(
+          (item) => item.checked,
+        );
+
+        newData[storeIndex].checked = allItemsChecked;
+        setSelectAll(newData.every((store) => store.checked));
+        setData(newData);
+      }
+    }
   };
 
   return (
-    <FlexBox col padding="2rem 1.4rem" gap="2.4rem">
-      <MediumText size={18} color={theme.color.gray.main}>
-        {getTitle(method)}
-      </MediumText>
-      {listData?.map((item, idx) => <CartItem key={idx} data={item} />)}
-    </FlexBox>
-  );
-};
-
-const CartList = ({ data }: { data: any }) => {
-  // ========= api 연동 시 체크박스 기능 추가 ==========
-  //   const [selectAll, setSelectAll] = useState(false);
-  //   const [checkboxes, setCheckboxes] = useState([
-  //     { id: 1, label: '체크 박스 1', checked: false },
-  //     { id: 2, label: '체크 박스 2', checked: false },
-  //     { id: 3, label: '체크 박스 3', checked: false },
-  //   ]);
-
-  //   const handleSelectAll = () => {
-  //     const updatedCheckboxes = checkboxes.map((checkbox) => ({
-  //       ...checkbox,
-  //       checked: !selectAll,
-  //     }));
-  //     setCheckboxes(updatedCheckboxes);
-  //     setSelectAll(!selectAll);
-  //   };
-
-  //   const handleCheckboxChange = (id: number) => {
-  //     const updatedCheckboxes = checkboxes.map((checkbox) =>
-  //       checkbox.id === id
-  //         ? { ...checkbox, checked: !checkbox.checked }
-  //         : checkbox,
-  //     );
-  //     setCheckboxes(updatedCheckboxes);
-  //     setSelectAll(updatedCheckboxes.every((checkbox) => checkbox.checked));
-  //   };
-  const [checked, setChecked] = useState(true);
-
-  return (
-    <>
+    <FlexBox col gap="2rem">
       <FlexBox
         align="center"
         gap="1rem"
         padding="2rem 1.4rem"
+        fullWidth
         style={{ borderBottom: `0.05rem solid ${theme.color.gray[50]}` }}
       >
         <FlexBox align="center" gap="0.8rem">
-          <CheckBox checked={checked}>
-            <input
-              type="checkbox"
-              checked={checked}
-              onChange={(e) => setChecked(e.currentTarget.checked)}
-            />
-            <div>
-              <FaCheck
-                size={12}
-                color={theme.color.tint.white}
-                style={{
-                  visibility: checked ? 'visible' : 'hidden',
-                }}
-              />
-            </div>
-          </CheckBox>
+          <CheckBox checked={selectAll} onChange={handleSelectAll} />
           <MediumText size={14} color={theme.color.gray.main}>
             전체
           </MediumText>
         </FlexBox>
         <MediumText size={14} color={theme.color.gray.main}>
-          1 입양권
+          {totalItemCount} 입양건
         </MediumText>
       </FlexBox>
-      <CartCategory listData={data} method="COMMON" />
-      <CartCategory listData={data} method="SAFETY" />
-      <CartCategory listData={data} method="PICKUP" />
+      {data.map((el: any, idx: number) => (
+        <CartStoreSection
+          key={idx}
+          data={el}
+          handleSelectStore={handleSelectStore}
+          handleSelectItem={handleSelectItem}
+          storeIdx={idx}
+        />
+      ))}
       <FlexBox
         col
-        gap="2.4rem"
+        gap="1rem"
         padding="1.8rem 1.4rem"
+        fullWidth
         style={{ borderTop: `0.05rem solid ${theme.color.gray[50]}` }}
       >
-        <FlexBox align="center" gap="1.2rem">
+        <FlexBox align="center" gap="1.2rem" style={{ marginBottom: '1.4rem' }}>
           <BoldText size={16} color={theme.color.gray.main}>
             결제할 입양건
           </BoldText>
           <MediumText size={16} color={theme.color.blue[70]}>
-            총 1건
+            총 {totalCount}건
+          </MediumText>
+        </FlexBox>
+        <FlexBox justify="space-between" align="center" fullWidth>
+          <MediumText size={12} color={theme.color.gray.main}>
+            총 입양 금액
+          </MediumText>
+          <MediumText size={12} color={theme.color.gray.main}>
+            {totalOriginalPrice.toLocaleString()} 원
+          </MediumText>
+        </FlexBox>
+        <FlexBox justify="space-between" align="center" fullWidth>
+          <MediumText size={12} color={theme.color.gray.main}>
+            할인 금액
+          </MediumText>
+          <MediumText size={12} color={theme.color.tint.red}>
+            {`-
+            ${(totalOriginalPrice - totalDiscountedPrices).toLocaleString()}
+            원`}
           </MediumText>
         </FlexBox>
         <FlexBox
           justify="space-between"
-          align="center"
-          style={{ width: '100%' }}
+          align={isOpenToggle ? 'flex-end' : 'center'}
+          fullWidth
         >
-          <MediumText size={16} color={theme.color.gray.main}>
-            입양 금액
-          </MediumText>
-          <MediumText size={16} color={theme.color.gray.main}>
-            30,000 원
+          <FlexBox col gap="1rem">
+            <FlexBox gap="0.6rem" align="center">
+              <MediumText size={12} color={theme.color.gray.main}>
+                운송비
+              </MediumText>
+              <ToggleButton
+                onClick={() => setIsOpenToggle((prev) => !prev)}
+                $isOpenToggle={isOpenToggle}
+              >
+                <IoIosArrowDown size={10} color={theme.color.gray[60]} />
+              </ToggleButton>
+            </FlexBox>
+            {isOpenToggle && (
+              <FlexBox col gap="0.6rem">
+                <RegularText
+                  size={12}
+                  color={theme.color.gray[50]}
+                  style={{ whiteSpace: 'pre-wrap' }}
+                >
+                  {`- 일반운송비   ---------   +${totalCommonDeliveryFees.toLocaleString()}`}
+                </RegularText>
+                <RegularText
+                  size={12}
+                  color={theme.color.gray[50]}
+                  style={{ whiteSpace: 'pre-wrap' }}
+                >
+                  {`- 안전운송비   ---------   +${totalSafetyDeliveryFees.toLocaleString()}`}
+                </RegularText>
+                <RegularText
+                  size={12}
+                  color={theme.color.gray[50]}
+                  style={{ whiteSpace: 'pre-wrap' }}
+                >
+                  {'- 매장픽업      ---------   +0'}
+                </RegularText>
+              </FlexBox>
+            )}
+          </FlexBox>
+          <MediumText size={12} color={theme.color.gray.main}>
+            {(
+              totalCommonDeliveryFees + totalSafetyDeliveryFees
+            ).toLocaleString()}{' '}
+            원
           </MediumText>
         </FlexBox>
       </FlexBox>
-    </>
+    </FlexBox>
   );
 };
 
 export default CartList;
 
-const CheckBox = styled.label<{ checked: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  cursor: pointer;
-
-  input {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
-
-  div {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 50%;
-    border: ${({ checked, theme }) =>
-      checked ? 'none' : `solid 0.1rem ${theme.color.gray[50]}`};
-    background: ${({ checked, theme }) =>
-      checked ? theme.color.blue[80] : 'white'};
-  }
+const ToggleButton = styled.button<{ $isOpenToggle: boolean }>`
+  padding: 0.2rem;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.color.gray[30]};
+  transform: ${({ $isOpenToggle }) => ($isOpenToggle ? 'rotate(180deg)' : '')};
 `;

--- a/src/components/organisms/CartList.tsx
+++ b/src/components/organisms/CartList.tsx
@@ -14,7 +14,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
     totalCommonDeliveryFees,
     totalSafetyDeliveryFees,
   } = checkedItemData;
-  const [isOpenToggle, setIsOpenToggle] = useState(true);
+  const [isOpenToggle, setIsOpenToggle] = useState(false);
   const totalItemCount = data.reduce(
     (total, store) => total + store.items.length,
     0,
@@ -150,12 +150,14 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
               <MediumText size={12} color={theme.color.gray.main}>
                 운송비
               </MediumText>
-              <ToggleButton
-                onClick={() => setIsOpenToggle((prev) => !prev)}
-                $isOpenToggle={isOpenToggle}
-              >
-                <IoIosArrowDown size={10} color={theme.color.gray[60]} />
-              </ToggleButton>
+              {totalCommonDeliveryFees + totalSafetyDeliveryFees !== 0 && (
+                <ToggleButton
+                  onClick={() => setIsOpenToggle((prev) => !prev)}
+                  $isOpenToggle={isOpenToggle}
+                >
+                  <IoIosArrowDown size={10} color={theme.color.gray[60]} />
+                </ToggleButton>
+              )}
             </FlexBox>
             {isOpenToggle && (
               <FlexBox col gap="0.6rem">
@@ -164,21 +166,16 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
                   color={theme.color.gray[50]}
                   style={{ whiteSpace: 'pre-wrap' }}
                 >
-                  {`- 일반운송비   ---------   +${totalCommonDeliveryFees.toLocaleString()}`}
+                  • 일반운송비 &nbsp;&nbsp;-----------&nbsp;&nbsp; +{' '}
+                  {totalCommonDeliveryFees.toLocaleString()}
                 </RegularText>
                 <RegularText
                   size={12}
                   color={theme.color.gray[50]}
                   style={{ whiteSpace: 'pre-wrap' }}
                 >
-                  {`- 안전운송비   ---------   +${totalSafetyDeliveryFees.toLocaleString()}`}
-                </RegularText>
-                <RegularText
-                  size={12}
-                  color={theme.color.gray[50]}
-                  style={{ whiteSpace: 'pre-wrap' }}
-                >
-                  {'- 매장픽업      ---------   +0'}
+                  • 안전운송비 &nbsp;&nbsp;-----------&nbsp;&nbsp; +{' '}
+                  {totalSafetyDeliveryFees.toLocaleString()}
                 </RegularText>
               </FlexBox>
             )}

--- a/src/interfaces/cart.ts
+++ b/src/interfaces/cart.ts
@@ -1,0 +1,53 @@
+import { SetStateAction } from 'react';
+
+export interface CartItemData {
+  id: number;
+  storeName: string;
+  productId: number;
+  productName: string;
+  productThumbnailUrl: string;
+  productPrice: number;
+  productDiscountRate: number;
+  productDiscountPrice: number;
+  quantity: number;
+  sex: string;
+  deliveryMethod: string;
+  deliveryFee: number;
+  isOnSale: boolean;
+  safeDeliveryFee: number;
+  commonDeliveryFee: number;
+  pickUpDeliveryFee: number;
+  maleAdditionalPrice: number;
+  femaleAdditionalPrice: number;
+  checked: boolean;
+}
+
+export interface CartStoreSectionData {
+  storeName: string;
+  items: CartItemData[];
+  checked: boolean;
+}
+
+export interface CartStoreSection {
+  data: CartStoreSectionData;
+  handleSelectStore: (storeName: string, value: boolean) => void;
+  handleSelectItem: (storeName: string, itemId: number, value: boolean) => void;
+  storeIdx: number;
+}
+
+export interface CartList {
+  data: CartStoreSectionData[];
+  setData: React.Dispatch<SetStateAction<CartStoreSectionData[]>>;
+  checkedItemData: {
+    totalCount: number;
+    totalOriginalPrice: number;
+    totalDiscountedPrices: number;
+    totalCommonDeliveryFees: number;
+    totalSafetyDeliveryFees: number;
+  };
+}
+
+export interface CartItem {
+  data: CartItemData;
+  handleSelectItem: (storeName: string, itemId: number, value: boolean) => void;
+}

--- a/src/interfaces/payment.ts
+++ b/src/interfaces/payment.ts
@@ -7,18 +7,3 @@ export interface Address {
   detailAddress: string;
   isDefaultAddress: boolean;
 }
-
-export interface CartItemDetails {
-  id: number;
-  storeName: string;
-  productId: number;
-  productName: string;
-  productThumbnailUrl: string;
-  productPrice: number;
-  productDiscountRate: number;
-  productDiscountPrice: number;
-  quantity: number;
-  isMale: boolean;
-  deliveryMethod: string;
-  isOnSale: boolean;
-}

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -4,41 +4,159 @@ import { BlueButton, TopNav } from '../components/molecules';
 import { theme } from '../styles/theme';
 import { useNavigate } from 'react-router-dom';
 import { CartList } from '../components/organisms';
+import { CartStoreSectionData } from '../interfaces/cart';
+import { useState } from 'react';
 
 const CartPage = () => {
   const navigate = useNavigate();
-  const data = [
+  const [data, setData] = useState<CartStoreSectionData[]>([
     {
-      id: 1,
       storeName: 'S아쿠아',
-      productId: 1,
-      productName: '알비노 풀레드 아시안 고정구피',
-      productThumbnailUrl:
-        'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
-      productPrice: 30000,
-      productDiscountRate: 30,
-      productDiscountPrice: 21000,
-      quantity: 1,
-      isMale: true,
-      deliveryMethod: 'SAFETY',
-      isOnSale: true,
+      items: [
+        {
+          id: 1,
+          storeName: 'S아쿠아',
+          productId: 1,
+          productName: '알비노 풀레드 아시안 고정구피',
+          productThumbnailUrl:
+            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+          productPrice: 30000,
+          productDiscountRate: 30,
+          productDiscountPrice: 21000,
+          quantity: 1,
+          sex: 'MALE',
+          deliveryMethod: 'COMMON',
+          deliveryFee: 3000,
+          isOnSale: true,
+          safeDeliveryFee: 5000,
+          commonDeliveryFee: 3000,
+          pickUpDeliveryFee: 0,
+          maleAdditionalPrice: 1000,
+          femaleAdditionalPrice: 1000,
+          checked: true,
+        },
+        {
+          id: 2,
+          storeName: 'S아쿠아',
+          productId: 2,
+          productName: '알비노 풀레드 아시안 고정구피',
+          productThumbnailUrl:
+            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+          productPrice: 30000,
+          productDiscountRate: 30,
+          productDiscountPrice: 21000,
+          quantity: 1,
+          sex: 'MALE',
+          deliveryMethod: 'SAFETY',
+          deliveryFee: 5000,
+          isOnSale: true,
+          safeDeliveryFee: 5000,
+          commonDeliveryFee: 3000,
+          pickUpDeliveryFee: 0,
+          maleAdditionalPrice: 1000,
+          femaleAdditionalPrice: 1000,
+          checked: true,
+        },
+      ],
+      checked: true,
     },
     {
-      id: 1,
-      storeName: 'S아쿠아',
-      productId: 1,
-      productName: '알비노 풀레드 아시안 고정구피',
-      productThumbnailUrl:
-        'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
-      productPrice: 30000,
-      productDiscountRate: null,
-      productDiscountPrice: 21000,
-      quantity: 1,
-      isMale: true,
-      deliveryMethod: 'SAFETY',
-      isOnSale: true,
+      storeName: '현대올림피아드 아쿠아',
+      items: [
+        {
+          id: 3,
+          storeName: '현대올림피아드 아쿠아',
+          productId: 3,
+          productName: '알비노 풀레드 아시안 고정구피',
+          productThumbnailUrl:
+            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+          productPrice: 30000,
+          productDiscountRate: 30,
+          productDiscountPrice: 21000,
+          quantity: 1,
+          sex: 'MALE',
+          deliveryMethod: 'COMMON',
+          deliveryFee: 3000,
+          isOnSale: true,
+          safeDeliveryFee: 5000,
+          commonDeliveryFee: 3000,
+          pickUpDeliveryFee: 0,
+          maleAdditionalPrice: 1000,
+          femaleAdditionalPrice: 1000,
+          checked: true,
+        },
+        {
+          id: 4,
+          storeName: '현대올림피아드 아쿠아',
+          productId: 4,
+          productName: '알비노 풀레드 아시안 고정구피',
+          productThumbnailUrl:
+            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
+          productPrice: 30000,
+          productDiscountRate: 30,
+          productDiscountPrice: 21000,
+          quantity: 1,
+          sex: 'MALE',
+          deliveryMethod: 'PICKUP',
+          deliveryFee: 0,
+          isOnSale: true,
+          safeDeliveryFee: 5000,
+          commonDeliveryFee: 3000,
+          pickUpDeliveryFee: 0,
+          maleAdditionalPrice: 1000,
+          femaleAdditionalPrice: 1000,
+          checked: true,
+        },
+      ],
+      checked: true,
     },
-  ];
+  ]);
+
+  const checkedItemData = data.reduce(
+    (total, store) => {
+      const checkedItems = store.items.filter((item) => item.checked);
+      // 선택된 상품의 원가
+      const originalPrices = checkedItems.reduce((totalPrice, item) => {
+        return totalPrice + item.productPrice;
+      }, 0);
+
+      // 선택된 상품의 할인된 가격
+      const discountedPrices = checkedItems.reduce((totalPrice, item) => {
+        return totalPrice + item.productDiscountPrice;
+      }, 0);
+
+      // 선택된 상품의 일반운송비
+      const commonDeliveryFees = checkedItems.reduce((totalFee, item) => {
+        if (item.deliveryMethod === 'COMMON') {
+          return totalFee + item.deliveryFee;
+        }
+        return totalFee;
+      }, 0);
+      // 선택된 상품의 안전운송비
+      const safetyDeliveryFees = checkedItems.reduce((totalFee, item) => {
+        if (item.deliveryMethod === 'SAFETY') {
+          return totalFee + item.deliveryFee;
+        }
+        return totalFee;
+      }, 0);
+      return {
+        totalCount: total.totalCount + checkedItems.length,
+        totalOriginalPrice: total.totalOriginalPrice + originalPrices,
+        totalDiscountedPrices: total.totalDiscountedPrices + discountedPrices,
+        totalCommonDeliveryFees:
+          total.totalCommonDeliveryFees + commonDeliveryFees,
+        totalSafetyDeliveryFees:
+          total.totalSafetyDeliveryFees + safetyDeliveryFees,
+      };
+    },
+    {
+      totalCount: 0,
+      totalOriginalPrice: 0,
+      totalDiscountedPrices: 0,
+      totalCommonDeliveryFees: 0,
+      totalSafetyDeliveryFees: 0,
+    },
+  );
 
   return (
     <>
@@ -62,9 +180,16 @@ const CartPage = () => {
         </FlexBox>
       ) : (
         <>
-          <CartList data={data} />
+          <CartList
+            data={data}
+            setData={setData}
+            checkedItemData={checkedItemData}
+          />
           <PayButton>
-            <BlueButton text="총 1개 | 30,000원 결제하기" onClick={() => {}} />
+            <BlueButton
+              text={`총 ${checkedItemData.totalCount}개 | ${(checkedItemData.totalDiscountedPrices + checkedItemData.totalCommonDeliveryFees + checkedItemData.totalSafetyDeliveryFees).toLocaleString()}원 결제하기`}
+              onClick={() => {}}
+            />
           </PayButton>
         </>
       )}


### PR DESCRIPTION
> Close #116

## 사진
### 상품 선택시
![image](https://github.com/petqua/frontend/assets/123801984/b98cf7eb-ec8a-40c9-a3b7-4b909ed291bf)

### 상품 미선택시
![image](https://github.com/petqua/frontend/assets/123801984/b6ab5e2b-a9bf-4431-976f-d5b5c6c3fbea)

### 선택한 상품정보 요약
![image](https://github.com/petqua/frontend/assets/123801984/0e413dba-604e-4285-b48d-15aa3f7ed804)

## 커밋 리스트

#### ✅ feat: 봉달목록 레이아웃 디자인 변경

- 판매처 별로 상품 분류
- 운송비 토글 기능
- 상품 별 운송비 계산

#### ✅ feat: 체크박스 기능 추가

#### ✅ feat: 체크된 상품들의 정보 계산

#### ✅ refactor: 수정 사항 반영

- utils/delivery.ts 함수 사용
- 운송비 0원일 시 토글 제거
- 매장픽업 운송비 정보 제거

## Comment

- 체크기능 로직 구현하기 너무 빡셌음.....
- 저희 디자인 한번 더 변경될 예정인데 그건 또 추후 리팩토링에서 할게요...ㅎㅎ 저도 좀 너무 많이 변경되는 느낌이 있기는 하네요ㅠ
