### PR TITLE
[#123] 카테고리 리스트 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query-devtools": "^5.17.21",
         "axios": "^1.6.5",
         "dotenv": "^16.4.1",
+        "qs": "^6.12.0",
         "react": "^18.2.0",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.9",
+        "@types/qs": "^6.9.12",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@types/react-infinite-scroller": "^1.2.5",
@@ -1848,6 +1850,12 @@
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
       "devOptional": true
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.12",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
+      "integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg==",
+      "dev": true
+    },
     "node_modules/@types/react": {
       "version": "18.2.52",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.52.tgz",
@@ -2530,14 +2538,18 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-      "dev": true,
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2870,17 +2882,19 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-properties": {
@@ -3039,6 +3053,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-iterator-helpers": {
@@ -3688,7 +3721,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3738,15 +3770,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-      "dev": true,
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3876,7 +3911,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -3918,12 +3952,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3933,7 +3966,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3945,7 +3977,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3972,7 +4003,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4909,7 +4939,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5298,6 +5327,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
+      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5735,16 +5778,16 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
-      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
-        "define-data-property": "^1.1.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5791,14 +5834,17 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7690,6 +7736,12 @@
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
       "devOptional": true
     },
+    "@types/qs": {
+      "version": "6.9.12",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
+      "integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg==",
+      "dev": true
+    },
     "@types/react": {
       "version": "18.2.52",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.52.tgz",
@@ -8152,14 +8204,15 @@
       }
     },
     "call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-      "dev": true,
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       }
     },
     "callsites": {
@@ -8383,14 +8436,13 @@
       }
     },
     "define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "requires": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       }
     },
     "define-properties": {
@@ -8517,6 +8569,19 @@
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.13"
       }
+    },
+    "es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "requires": {
+        "get-intrinsic": "^1.2.4"
+      }
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-iterator-helpers": {
       "version": "1.0.15",
@@ -9001,8 +9066,7 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.6",
@@ -9034,11 +9098,11 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-      "dev": true,
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "requires": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
@@ -9135,7 +9199,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -9165,25 +9228,22 @@
       "dev": true
     },
     "has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "requires": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       }
     },
     "has-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
     },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-tostringtag": {
       "version": "1.0.2",
@@ -9198,7 +9258,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -9869,8 +9928,7 @@
     "object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -10138,6 +10196,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
+    },
+    "qs": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
+      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "requires": {
+        "side-channel": "^1.0.6"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -10418,16 +10484,16 @@
       }
     },
     "set-function-length": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
-      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "requires": {
-        "define-data-property": "^1.1.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       }
     },
     "set-function-name": {
@@ -10462,14 +10528,14 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
       }
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query-devtools": "^5.17.21",
     "axios": "^1.6.5",
     "dotenv": "^16.4.1",
+    "qs": "^6.12.0",
     "react": "^18.2.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.9",
+    "@types/qs": "^6.9.12",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@types/react-infinite-scroller": "^1.2.5",

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -3,6 +3,7 @@ import {
   getProductsAPI,
   getProductDetailAPI,
   getCategoryProductsAPI,
+  getCategoriesAPI,
 } from './productAPI';
 import { getSearchProductsAPI, getTrendingKeywordsAPI } from './searchAPI';
 import {
@@ -36,6 +37,7 @@ export {
   postNewAddressAPI,
   getCartsAPI,
   getCategoryProductsAPI,
+  getCategoriesAPI,
   getWishesAPI,
   postWishAPI,
 };

--- a/src/apis/productAPI.ts
+++ b/src/apis/productAPI.ts
@@ -5,6 +5,7 @@ import {
   GetCategoryProductsAPIParams,
 } from '../interfaces/product';
 import { client } from './axiosInstance';
+import qs from 'qs';
 
 export const getProductsAPI = async ({
   lastViewedId,
@@ -127,6 +128,28 @@ export const getCategoryProductsAPI = async ({
         lastViewedId,
         limit,
         sorter,
+      },
+      paramsSerializer: (params) =>
+        qs.stringify(params, { arrayFormat: 'repeat' }),
+    });
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      console.error('Server Error:', error.response.data);
+    } else {
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};
+
+export const getCategoriesAPI = async (
+  family: string,
+): Promise<string[]> => {
+  try {
+    const res = await client.get('/categories', {
+      params: {
+        family,
       },
     });
     return res.data;

--- a/src/components/molecules/Filter.tsx
+++ b/src/components/molecules/Filter.tsx
@@ -7,41 +7,63 @@ import { formatFilter } from '../../utils/format';
 import { IoOptionsOutline } from 'react-icons/io5';
 
 interface Filter {
-  value: string;
+  title: string;
+  value?: string | null;
   setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
   handleFilterClick?: () => void;
   hasIcon?: boolean;
 }
 
 const Filter = ({
+  title,
   value,
   setIsOpenModal,
   handleFilterClick,
   hasIcon,
 }: Filter) => {
+  const isSelected = value !== null;
+
   return (
     <Container
       onClick={() => {
         handleFilterClick?.();
         setIsOpenModal((prev) => !prev);
       }}
+      $isSelected={isSelected}
     >
-      {hasIcon && <IoOptionsOutline size={18} color={theme.color.gray[50]} />}
-      <MediumText size={14} color={theme.color.gray[50]}>
-        {formatFilter(value)}
+      {hasIcon && (
+        <IoOptionsOutline
+          size={18}
+          color={isSelected ? theme.color.tint.white : theme.color.gray[50]}
+        />
+      )}
+      <MediumText
+        size={14}
+        color={isSelected ? theme.color.tint.white : theme.color.gray[50]}
+      >
+        {formatFilter(value || title)}
       </MediumText>
-      {!hasIcon && <FaAngleDown color={theme.color.gray[50]} size={12} />}
+      {!hasIcon && (
+        <FaAngleDown
+          color={isSelected ? theme.color.tint.white : theme.color.gray[50]}
+          size={12}
+        />
+      )}
     </Container>
   );
 };
 
 export default Filter;
 
-const Container = styled.div`
+const Container = styled.div<{ $isSelected: boolean }>`
   display: flex;
   gap: 0.4rem;
   align-items: center;
   padding: 0.6rem 1.2rem;
   border-radius: 2rem;
-  border: 0.5px solid ${({ theme }) => theme.color.gray[50]};
+  border: ${({ theme, $isSelected }) =>
+    $isSelected ? 'none' : `0.5px solid ${theme.color.gray[50]}`};
+  background-color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.color.blue[70] : theme.color.tint.white};
+  cursor: pointer;
 `;

--- a/src/components/molecules/TopNav.tsx
+++ b/src/components/molecules/TopNav.tsx
@@ -14,6 +14,7 @@ interface TopNav {
   searchBar?: boolean;
   title?: string;
   isBlue?: boolean; // 타이틀 파란색 여부
+  backToHome?: boolean; // 상품 리스트 페이지에서 필터링에 관계없이 홈화면으로 바로 이동시 필요
 }
 
 const TopNav = ({
@@ -25,6 +26,7 @@ const TopNav = ({
   searchBar,
   title,
   isBlue,
+  backToHome,
 }: TopNav) => {
   const navigate = useNavigate();
 
@@ -41,7 +43,7 @@ const TopNav = ({
             <GoChevronLeft
               size={24}
               color={theme.color.gray.main}
-              onClick={() => navigate(-1)}
+              onClick={() => (backToHome ? navigate('/') : navigate(-1))}
               style={{ cursor: 'pointer' }}
             />
           )}

--- a/src/components/organisms/CategoryList.tsx
+++ b/src/components/organisms/CategoryList.tsx
@@ -18,47 +18,47 @@ const GridContainer = styled.div`
   }
 `;
 
-// 어디로 nav할 지도 정해서 추가해야함.
+// 어디로 nav할지도 정해서 추가해야함.
 const CATEGORY_ARRAY = [
   {
     name: '송사리과',
     src: '/icons/category/1.svg',
-    path: '/1',
+    path: '/product?type=killfish',
   },
   {
     name: '카라신과',
     src: '/icons/category/2.svg',
-    path: '/2',
+    path: '/product?type=characidae',
   },
   {
     name: '잉어과',
     src: '/icons/category/3.svg',
-    path: '/3',
+    path: '/product?type=carp',
   },
   {
     name: '기수어과',
     src: '/icons/category/4.svg',
-    path: '/4',
+    path: '/product?type=brackishWaterFish',
   },
   {
     name: '대형어',
     src: '/icons/category/5.svg',
-    path: '/5',
+    path: '/product?type=largeFish',
   },
   {
     name: '아나바스과',
     src: '/icons/category/6.svg',
-    path: '/6',
+    path: '/product?type=anabantidae',
   },
   {
     name: '메기과',
     src: '/icons/category/7.svg',
-    path: '/7',
+    path: '/product?type=siluridae',
   },
   {
     name: '더보기',
     src: '/icons/category/8.svg',
-    path: '/8',
+    path: '',
   },
 ];
 

--- a/src/components/organisms/ProductList.tsx
+++ b/src/components/organisms/ProductList.tsx
@@ -16,7 +16,9 @@ const ProductList = ({
     <FlexBox col gap="2rem" style={{ padding: '1.4rem' }}>
       <MediumText size={14} color={theme.color.gray.main}>
         {/* 수입입고 소식 리스트를 위한 조건부 */}
-        {length ? `${length}마리 반려어` : '새로운 반려어가 왔어요!'}
+        {length === undefined
+          ? '새로운 반려어가 왔어요!'
+          : `${length}마리 반려어`}
       </MediumText>
       {isInfinite ? (
         <InfiniteScroll hasMore={hasNextPage} loadMore={() => fetchNextPage()}>

--- a/src/components/organisms/ReviewList.tsx
+++ b/src/components/organisms/ReviewList.tsx
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom';
 import { FaCheck } from 'react-icons/fa6';
 
 interface ReviewList {
-  score: number | undefined;
+  score: number | null;
   setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
 }
 
@@ -104,7 +104,12 @@ const ReviewList = ({ score, setIsOpenModal }: ReviewList) => {
             최신순
           </BoldText>
         </FlexBox>
-        <Filter value="필터" setIsOpenModal={setIsOpenModal} hasIcon />
+        <Filter
+          title="필터"
+          value={score ? '필터' : null}
+          setIsOpenModal={setIsOpenModal}
+          hasIcon
+        />
       </FilterContainer>
       <InfiniteScroll loadMore={() => fetchNextPage()} hasMore={hasNextPage}>
         {data?.pages?.map((items, firstIdx) => {

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -12,6 +12,7 @@ import DeliveryAddressModal from './modals/DeliveryAddressModal';
 import ListModal from './modals/ListModal';
 import ReviewModal from './modals/ReviewModal';
 import OptionModal from './modals/OptionModal';
+import SpeciesModal from './modals/SpeciesModal';
 import CartFishList from './CartFishList';
 import CartList from './CartList';
 import ImageDetail from './ImageDetail';
@@ -30,6 +31,7 @@ export {
   ReviewList,
   ListModal,
   ReviewModal,
+  SpeciesModal,
   DeliveryAddressModal,
   CartFishList,
   OptionModal,

--- a/src/components/organisms/modals/ListModal.tsx
+++ b/src/components/organisms/modals/ListModal.tsx
@@ -3,27 +3,18 @@ import { RegularText, BoldText, FlexBox } from '../../atoms';
 import { theme } from '../../../styles/theme';
 import { FaCheck } from 'react-icons/fa6';
 import Modal from '../../molecules/Modal';
-
-interface Option {
-  name: string;
-  title: string;
-}
+import { formatFilter } from '../../../utils/format';
+import { useSearchParams } from 'react-router-dom';
 
 interface ListModal {
-  value: string;
+  value: string | null;
   setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
-  setValue: React.Dispatch<SetStateAction<string>>;
-  options: Option[];
-  title: string;
+  options: string[];
+  type: string;
 }
 
-const ListModal = ({
-  setIsOpenModal,
-  setValue,
-  value,
-  options,
-  title,
-}: ListModal) => {
+const ListModal = ({ setIsOpenModal, value, options, type }: ListModal) => {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [visible, setVisible] = useState(true);
 
   // 모달 닫을 시 애니메이션 적용하기 위한 딜레이
@@ -34,8 +25,23 @@ const ListModal = ({
     }, 250);
   };
 
+  const getTitle = (type: string) => {
+    switch (type) {
+      case 'deliveryMethod':
+        return '운송방법';
+      case 'sorter':
+        return '정렬';
+      default:
+        return type;
+    }
+  };
+
   return (
-    <Modal title={title} visible={visible} handleCloseModal={handleCloseModal}>
+    <Modal
+      title={formatFilter(value || getTitle(type))}
+      visible={visible}
+      handleCloseModal={handleCloseModal}
+    >
       <>
         {options.map((item, idx) => (
           <FlexBox
@@ -44,21 +50,27 @@ const ListModal = ({
             justify="space-between"
             style={{ width: '100%', padding: '2.4rem 3.2rem' }}
             onClick={() => {
-              setValue(item.name);
+              if (value === item) {
+                searchParams.delete(type);
+                setSearchParams(searchParams);
+              } else {
+                searchParams.set(type, item);
+                setSearchParams(searchParams);
+              }
               handleCloseModal();
             }}
           >
-            {item.name === value ? (
+            {item === value ? (
               <BoldText size={16} color={theme.color.gray.main}>
-                {item.title}
+                {formatFilter(item)}
               </BoldText>
             ) : (
               <RegularText size={16} color={theme.color.gray.main}>
-                {item.title}
+                {formatFilter(item)}
               </RegularText>
             )}
 
-            {item.name === value && (
+            {item === value && (
               <FaCheck color={theme.color.gray.main} size={18} />
             )}
           </FlexBox>

--- a/src/components/organisms/modals/ReviewModal.tsx
+++ b/src/components/organisms/modals/ReviewModal.tsx
@@ -5,9 +5,9 @@ import { BlueButton, StarRating } from '../../molecules';
 import Modal from '../../molecules/Modal';
 
 interface ReviewModal {
-  value: number | undefined;
+  value: number | null;
   setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
-  setValue: React.Dispatch<SetStateAction<number | undefined>>;
+  setValue: React.Dispatch<SetStateAction<number | null>>;
   options: number[];
 }
 
@@ -50,7 +50,7 @@ const ReviewModal = ({
               onClick={() => {
                 selectedValue !== score
                   ? setSelectedValue(score)
-                  : setSelectedValue(undefined);
+                  : setSelectedValue(null);
               }}
             >
               <StarRating size={22} gap={0.01} score={score} />

--- a/src/components/organisms/modals/SpeciesModal.tsx
+++ b/src/components/organisms/modals/SpeciesModal.tsx
@@ -1,0 +1,99 @@
+import { SetStateAction, useState } from 'react';
+import { RegularText, FlexBox } from '../../atoms';
+import { theme } from '../../../styles/theme';
+import { FaCheck } from 'react-icons/fa6';
+import { GoPlus } from 'react-icons/go';
+import Modal from '../../molecules/Modal';
+import styled from 'styled-components';
+import { useSearchParams } from 'react-router-dom';
+import { BlueButton } from '../../molecules';
+
+interface SpeciesModal {
+  value: string[];
+  setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
+  options: string[];
+}
+
+const SpeciesModal = ({ setIsOpenModal, value, options }: SpeciesModal) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedValues, setSelectedValues] = useState(value);
+  const [visible, setVisible] = useState(true);
+
+  // 모달 닫을 시 애니메이션 적용하기 위한 딜레이
+  const handleCloseModal = () => {
+    setVisible(false);
+    setTimeout(() => {
+      setIsOpenModal(false);
+    }, 250);
+  };
+
+  const handleItem = (species: string) => {
+    if (selectedValues.includes(species)) {
+      const filteredValues = selectedValues.filter((item) => item !== species);
+      setSelectedValues(filteredValues);
+    } else {
+      setSelectedValues([...selectedValues, species]);
+    }
+  };
+
+  return (
+    <Modal title="어종" visible={visible} handleCloseModal={handleCloseModal}>
+      <>
+        <GridLayout>
+          {options.map((item, idx) => {
+            const isSelected = selectedValues.includes(item);
+            return (
+              <FlexBox
+                key={idx}
+                padding="1.2rem"
+                justify="space-between"
+                align="center"
+                style={{
+                  height: '4.5rem',
+                  border: `0.5px solid ${isSelected ? theme.color.gray.main : theme.color.gray[60]}`,
+                  cursor: 'pointer',
+                }}
+                onClick={() => handleItem(item)}
+              >
+                <RegularText
+                  size={18}
+                  color={
+                    isSelected ? theme.color.gray.main : theme.color.gray[60]
+                  }
+                >
+                  {item}
+                </RegularText>
+                {isSelected ? (
+                  <FaCheck size={16} color={theme.color.gray.main} />
+                ) : (
+                  <GoPlus size={20} color={theme.color.gray[60]} />
+                )}
+              </FlexBox>
+            );
+          })}
+        </GridLayout>
+        <BlueButton
+          text="적용하기"
+          onClick={() => {
+            searchParams.set('species', selectedValues.join(','));
+            setSearchParams(searchParams);
+            handleCloseModal();
+          }}
+          isMargin
+          style={{ margin: '2rem' }}
+        />
+      </>
+    </Modal>
+  );
+};
+
+export default SpeciesModal;
+
+const GridLayout = styled.div`
+  padding: 1.4rem;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-column-gap: 0.8rem;
+  grid-row-gap: 1.2rem;
+`;

--- a/src/interfaces/product.ts
+++ b/src/interfaces/product.ts
@@ -111,9 +111,9 @@ export interface GetProductDetailAPI {
 
 export interface GetCategoryProductsAPIParams {
   family: string;
-  species?: string[];
-  deliveryMethod?: string;
+  species?: string[] | null;
+  deliveryMethod?: string | null;
   lastViewedId?: number;
   limit: number;
-  sorter?: string;
+  sorter?: string | null;
 }

--- a/src/interfaces/review.ts
+++ b/src/interfaces/review.ts
@@ -3,7 +3,7 @@ export interface GetReviewsAPIParams {
   lastViewedId?: number;
   limit: number;
   sorter?: string;
-  score?: number;
+  score?: number | null;
   photoOnly?: boolean;
 }
 

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -11,7 +11,7 @@ import { getReviewStatisticsAPI } from '../apis/reviewAPI';
 const ReviewPage = () => {
   const { productId } = useParams();
   const [isOpenModal, setIsOpenModal] = useState(false);
-  const [score, setScore] = useState<number | undefined>(undefined);
+  const [score, setScore] = useState<number | null>(null);
 
   const { data } = useQuery({
     queryKey: ['review-statistics', productId],

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -13,19 +13,15 @@ const SearchResultPage = () => {
   const query = searchParams.get('search_query') as string;
 
   const sortOptions = [
-    { name: 'SALE_PRICE_ASC', title: '낮은 가격순' },
-    { name: 'SALE_PRICE_DESC', title: '높은 가격순' },
-    { name: 'REVIEW_COUNT_DESC', title: '리뷰 많은 순' },
+    'SALE_PRICE_ASC',
+    'SALE_PRICE_DESC',
+    'REVIEW_COUNT_DESC',
   ];
 
-  const transitOptions = [
-    { name: 'SECURE_TRANSPORT', title: '안전운송' },
-    { name: 'STANDARD_TRANSPORT', title: '일반운송' },
-    { name: 'DIRECT_VISIT', title: '직접방문' },
-  ];
+  const transitOptions = ['SAFETY', 'COMMON', 'PICK_UP'];
 
-  const [sort, setSort] = useState('필터');
-  const [transit, setTransit] = useState('운송 방법');
+  const [sort] = useState(null);
+  const [transit] = useState(null);
   const [isOpenModal, setIsOpenModal] = useState(false);
 
   const [currentFilter, setCurrentFilter] = useState('');
@@ -52,11 +48,13 @@ const SearchResultPage = () => {
       <SearchBar />
       <FlexBox gap="1rem" style={{ padding: '1.4rem' }}>
         <Filter
+          title="운송방법"
           value={transit}
           setIsOpenModal={setIsOpenModal}
           handleFilterClick={() => setCurrentFilter('transit')}
         />
         <Filter
+          title="필터"
           value={sort}
           setIsOpenModal={setIsOpenModal}
           handleFilterClick={() => setCurrentFilter('sort')}
@@ -72,11 +70,10 @@ const SearchResultPage = () => {
 
       {isOpenModal && (
         <ListModal
+          type={currentFilter === 'sort' ? 'sorter' : 'deliveryMethod'}
           options={currentFilter === 'sort' ? sortOptions : transitOptions}
-          title="필터"
           value={currentFilter === 'sort' ? sort : transit}
           setIsOpenModal={setIsOpenModal}
-          setValue={currentFilter === 'sort' ? setSort : setTransit}
         />
       )}
       <BottomNavBar activeButton="search" />

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -6,14 +6,35 @@ export const formatFilter = (name: string) => {
       return '높은 가격순';
     case 'REVIEW_COUNT_DESC':
       return '리뷰 많은 순';
-    case 'SECURE_TRANSPORT':
+    case 'SAFETY':
       return '안전운송';
-    case 'STANDARD_TRANSPORT':
+    case 'COMMON':
       return '일반운송';
-    case 'DIRECT_VISIT':
+    case 'PICK_UP':
       return '직접방문';
     default:
       return name;
+  }
+};
+
+export const getCategory = (category: string) => {
+  switch (category) {
+    case 'killfish':
+      return '송사리과';
+    case 'characidae':
+      return '카라신과';
+    case 'carp':
+      return '잉어과';
+    case 'brackishWaterFish':
+      return '기수어과';
+    case 'largeFish':
+      return '대형어';
+    case 'anabantidae':
+      return '아나바스과';
+    case 'siluridae':
+      return '메기과';
+    default:
+      return category;
   }
 };
 


### PR DESCRIPTION
> Close #123 

## 사진
### 카테고리 리스트 페이지
![image](https://github.com/petqua/frontend/assets/123801984/63a456ed-438d-429c-b601-865a76485340)

### 변경된 리스트 모달
![image](https://github.com/petqua/frontend/assets/123801984/abf54880-5a0b-455d-8f49-32682197d38e)

## 커밋 리스트

#### ✅ refactor: 필터링 리팩토링

- 선택됐는지 여부에 따라 색상 변경
- 선택된 값이 필터링 박스에 뜨도록 변경

#### ✅ feat: 카테고리 리스트 api 연동

- 카테고리 상품목록 api
- 어과 목록 불러오기 api

#### ✅ feat: 어과 필터링 모달 제작

#### ✅ feat: 리스트 모달 로직 변경

- setValue로 상태관리 -> 쿼리 스트링으로 상태관리
- 선택한 값이 모달 제목에 표시

#### ✅ feat: 카테고리 리스트 페이지 구현

- 뒤로가기 버튼 시 홈으로 돌아가도록 구현

#### ✅ refactor: list modal 로직 변경에 따른 리팩토링

- list modal에 type 값 추가
- 쿼리스트링으로 필터 상태 관리 추후 변경 필요

## Comment

- 현재 어종필터는 백 api 수정중으로 오류가 뜰건데 이후 수정이 완료되면은 정상적으로 작동할 예정

#### 필터링 값을 쿼리 스트링 상태관리로 변경한 이유
상품의 상세페이지로 들어갔다가 다시 돌아올 경우 기존에 설정해놨던 필터링 값이 풀리기 때문에
뒤로가기 버튼을 누를 경우에도 홈으로 바로 이동하도록 구현



