### PR TITLE
[#103] 봉달목록 페이지 api 연동

### DIFF
--- a/src/apis/cartAPI.ts
+++ b/src/apis/cartAPI.ts
@@ -48,3 +48,18 @@ export const patchCartsOptionsAPI = async (
     throw error;
   }
 };
+
+// 봉달 삭제 API
+export const deleteCartsAPI = async (id: number) => {
+  try {
+    const res = await client.delete(`/carts/${id}`);
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      console.error('Server Error:', error.response.data);
+    } else {
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/apis/cartAPI.ts
+++ b/src/apis/cartAPI.ts
@@ -30,3 +30,21 @@ export const postCartsAPI = async (data: any) => {
     throw error;
   }
 };
+
+// 봉달 옵션 수정 API
+export const patchCartsOptionsAPI = async (
+  id: number | undefined,
+  data: any,
+) => {
+  try {
+    const res = await client.patch(`/carts/${id}/options`, data);
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      console.error('Server Error:', error.response.data);
+    } else {
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -22,6 +22,7 @@ import {
   getCartsAPI,
   postCartsAPI,
   patchCartsOptionsAPI,
+  deleteCartsAPI,
 } from './cartAPI';
 
 export {
@@ -42,6 +43,7 @@ export {
   getCartsAPI,
   postCartsAPI,
   patchCartsOptionsAPI,
+  deleteCartsAPI,
   getCategoryProductsAPI,
   getCategoriesAPI,
   getWishesAPI,

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -21,6 +21,7 @@ import { getDefaultAddressAPI, postNewAddressAPI } from './paymentAPI';
 import {
   getCartsAPI,
   postCartsAPI,
+  patchCartsOptionsAPI,
 } from './cartAPI';
 
 export {
@@ -40,6 +41,7 @@ export {
   postNewAddressAPI,
   getCartsAPI,
   postCartsAPI,
+  patchCartsOptionsAPI,
   getCategoryProductsAPI,
   getCategoriesAPI,
   getWishesAPI,

--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -3,13 +3,13 @@ import { theme } from '../../styles/theme';
 import { FaCheck } from 'react-icons/fa6';
 
 interface CheckBox {
-  checked: boolean;
+  checked: boolean | undefined;
   onChange: (e?: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const CheckBox = ({ checked, onChange }: CheckBox) => {
   return (
-    <Container checked={checked}>
+    <Container checked={checked || false}>
       <input type="checkbox" checked={checked} onChange={onChange} />
       <div>
         <FaCheck
@@ -27,9 +27,6 @@ const CheckBox = ({ checked, onChange }: CheckBox) => {
 export default CheckBox;
 
 const Container = styled.label<{ checked: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
   cursor: pointer;
 
   input {

--- a/src/components/molecules/CartStoreSection.tsx
+++ b/src/components/molecules/CartStoreSection.tsx
@@ -11,7 +11,10 @@ const CartStoreSection = ({
 }: CartStoreSection) => {
   const checkedItemsPrice = data.items.reduce((total, item) => {
     return (
-      total + (item.checked ? item.productDiscountPrice + item.deliveryFee : 0)
+      total +
+      (item.checked
+        ? item.productDiscountPrice * item.quantity + item.deliveryFee
+        : 0)
     );
   }, 0);
 

--- a/src/components/organisms/CartList.tsx
+++ b/src/components/organisms/CartList.tsx
@@ -5,8 +5,10 @@ import { useState } from 'react';
 import { IoIosArrowDown } from 'react-icons/io';
 import { CartList } from '../../interfaces/cart';
 import { CartStoreSection } from '../molecules';
+import { useCartStore } from '../../states';
 
-const CartList = ({ data, setData, checkedItemData }: CartList) => {
+const CartList = ({ checkedItemData }: CartList) => {
+  const { items, setItems } = useCartStore();
   const {
     totalCount,
     totalOriginalPrice,
@@ -15,7 +17,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
     totalSafetyDeliveryFees,
   } = checkedItemData;
   const [isOpenToggle, setIsOpenToggle] = useState(false);
-  const totalItemCount = data.reduce(
+  const totalItemCount = items?.reduce(
     (total, store) => total + store.items.length,
     0,
   );
@@ -24,7 +26,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
   const [selectAll, setSelectAll] = useState(true);
 
   const handleSelectAll = () => {
-    const newData = data.map((store) => ({
+    const newData = items?.map((store) => ({
       ...store,
       checked: !selectAll,
       items: store.items.map((item) => ({
@@ -34,11 +36,11 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
     }));
 
     setSelectAll(!selectAll);
-    setData(newData);
+    setItems(newData);
   };
 
   const handleSelectStore = (storeName: string, value: boolean) => {
-    const newData = data.map((store) =>
+    const newData = items?.map((store) =>
       store.storeName === storeName
         ? {
             ...store,
@@ -48,8 +50,8 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
         : store,
     );
 
-    setSelectAll(newData.every((item) => item.checked));
-    setData(newData);
+    setSelectAll(newData?.every((item) => item.checked));
+    setItems(newData);
   };
 
   const handleSelectItem = (
@@ -57,7 +59,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
     itemId: number,
     value: boolean,
   ) => {
-    const newData = [...data];
+    const newData = [...items];
     const storeIndex = newData.findIndex(
       (store) => store.storeName === storeName,
     );
@@ -73,8 +75,8 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
         );
 
         newData[storeIndex].checked = allItemsChecked;
+        setItems(newData);
         setSelectAll(newData.every((store) => store.checked));
-        setData(newData);
       }
     }
   };
@@ -98,7 +100,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
           {totalItemCount} 입양건
         </MediumText>
       </FlexBox>
-      {data.map((el: any, idx: number) => (
+      {items?.map((el: any, idx: number) => (
         <CartStoreSection
           key={idx}
           data={el}
@@ -127,7 +129,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
             총 입양 금액
           </MediumText>
           <MediumText size={12} color={theme.color.gray.main}>
-            {totalOriginalPrice.toLocaleString()} 원
+            {totalOriginalPrice?.toLocaleString()} 원
           </MediumText>
         </FlexBox>
         <FlexBox justify="space-between" align="center" fullWidth>
@@ -136,7 +138,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
           </MediumText>
           <MediumText size={12} color={theme.color.tint.red}>
             {`-
-            ${(totalOriginalPrice - totalDiscountedPrices).toLocaleString()}
+            ${(totalOriginalPrice - totalDiscountedPrices)?.toLocaleString()}
             원`}
           </MediumText>
         </FlexBox>
@@ -167,7 +169,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
                   style={{ whiteSpace: 'pre-wrap' }}
                 >
                   • 일반운송비 &nbsp;&nbsp;-----------&nbsp;&nbsp; +{' '}
-                  {totalCommonDeliveryFees.toLocaleString()}
+                  {totalCommonDeliveryFees?.toLocaleString()}
                 </RegularText>
                 <RegularText
                   size={12}
@@ -175,7 +177,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
                   style={{ whiteSpace: 'pre-wrap' }}
                 >
                   • 안전운송비 &nbsp;&nbsp;-----------&nbsp;&nbsp; +{' '}
-                  {totalSafetyDeliveryFees.toLocaleString()}
+                  {totalSafetyDeliveryFees?.toLocaleString()}
                 </RegularText>
               </FlexBox>
             )}
@@ -183,7 +185,7 @@ const CartList = ({ data, setData, checkedItemData }: CartList) => {
           <MediumText size={12} color={theme.color.gray.main}>
             {(
               totalCommonDeliveryFees + totalSafetyDeliveryFees
-            ).toLocaleString()}{' '}
+            )?.toLocaleString()}{' '}
             원
           </MediumText>
         </FlexBox>

--- a/src/components/organisms/modals/OptionModal.tsx
+++ b/src/components/organisms/modals/OptionModal.tsx
@@ -6,7 +6,7 @@ import Modal from '../../molecules/Modal';
 import styled from 'styled-components';
 import { FaMinus, FaPlus } from 'react-icons/fa6';
 import { useMutation } from '@tanstack/react-query';
-import { postCartsAPI } from '../../../apis';
+import { patchCartsOptionsAPI, postCartsAPI } from '../../../apis';
 import { usePopUpStore } from '../../../states';
 import { OptionModalData } from '../../../interfaces/product';
 // import { useNavigate } from 'react-router-dom';
@@ -106,6 +106,31 @@ const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
       console.error(err);
     },
   });
+
+  const { mutate: patchOptionsMutate } = useMutation({
+    mutationKey: ['patchOptions', data?.id],
+    mutationFn: () => patchCartsOptionsAPI(data?.id, requestData),
+    onSuccess: () => {
+      const changedItems = items.map((store) => {
+        if (store.storeName === data.storeName) {
+          return {
+            ...store,
+            items: store.items.map((item) => {
+              if (item.id === data.id) {
+                return { ...item, ...requestData };
+              } else return item;
+            }),
+          };
+        } else return store;
+      });
+      setItems(changedItems);
+      handleCloseModal();
+    },
+    onError: (err) => {
+      console.error(err);
+    },
+  });
+
 
   // 옵션 변경 기능
   const handleQuantity = (value: number) => {
@@ -239,7 +264,7 @@ const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
 
         {isEdit ? (
           <ButtonContainer>
-            <BlueButton text="변경 완료" onClick={() => {}} />
+            <BlueButton text="변경 완료" onClick={patchOptionsMutate} />
           </ButtonContainer>
         ) : (
           <ButtonContainer>

--- a/src/components/organisms/modals/OptionModal.tsx
+++ b/src/components/organisms/modals/OptionModal.tsx
@@ -7,9 +7,9 @@ import styled from 'styled-components';
 import { FaMinus, FaPlus } from 'react-icons/fa6';
 import { useMutation } from '@tanstack/react-query';
 import { patchCartsOptionsAPI, postCartsAPI } from '../../../apis';
-import { usePopUpStore } from '../../../states';
+import { usePopUpStore, useCartStore } from '../../../states';
 import { OptionModalData } from '../../../interfaces/product';
-// import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 interface OptionModal {
   setIsOpenModal: React.Dispatch<SetStateAction<boolean>>;
@@ -25,7 +25,7 @@ interface RequestData {
 }
 
 const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const [visible, setVisible] = useState(true);
   const [requestData, setRequestData] = useState<RequestData>({
     quantity: data?.quantity || 1,
@@ -36,7 +36,7 @@ const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
   const [calculatedPrice, setCalculatedPrice] = useState(
     data?.productDiscountPrice || 0,
   );
-  // const { items, setItems } = useCartStore();
+  const { items, setItems } = useCartStore();
   const { setState, setAction, setIsOpenPopUp } = usePopUpStore();
 
   const sexData = [
@@ -131,6 +131,26 @@ const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
     },
   });
 
+  const handleAdopt = () => {
+    setItems([
+      {
+        storeName: data?.storeName || '',
+        items: [
+          {
+            ...data,
+            ...requestData,
+            storeName: data?.storeName || '',
+            productName: data?.productName || '',
+            productThumbnailUrl: data?.productThumbnailUrl || '',
+            productPrice: data?.productPrice || 0,
+            productDiscountRate: data?.productDiscountRate || 0,
+            productDiscountPrice: calculatedPrice * requestData.quantity,
+          },
+        ],
+      },
+    ]);
+    navigate('/payment');
+  };
 
   // 옵션 변경 기능
   const handleQuantity = (value: number) => {
@@ -269,7 +289,7 @@ const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
         ) : (
           <ButtonContainer>
             <WhiteButton text="봉달하기" onClick={postCartsMutate} isRound />
-            <BlueButton text="입양하기" onClick={() => {}} />
+            <BlueButton text="입양하기" onClick={handleAdopt} />
           </ButtonContainer>
         )}
       </>

--- a/src/interfaces/cart.ts
+++ b/src/interfaces/cart.ts
@@ -1,7 +1,5 @@
-import { SetStateAction } from 'react';
-
 export interface CartItemData {
-  id: number;
+  id?: number;
   storeName: string;
   productId: number;
   productName: string;
@@ -11,21 +9,29 @@ export interface CartItemData {
   productDiscountPrice: number;
   quantity: number;
   sex: string;
-  deliveryMethod: string;
+  deliveryMethod: string | null;
   deliveryFee: number;
-  isOnSale: boolean;
-  safeDeliveryFee: number;
-  commonDeliveryFee: number;
-  pickUpDeliveryFee: number;
-  maleAdditionalPrice: number;
-  femaleAdditionalPrice: number;
-  checked: boolean;
+  isOnSale?: boolean;
+  safeDeliveryFee: number | null;
+  commonDeliveryFee: number | null;
+  pickUpDeliveryFee: number | null;
+  maleAdditionalPrice: number | null;
+  femaleAdditionalPrice: number | null;
+  checked?: boolean;
+}
+
+export interface CheckedItemData {
+  totalCount: number;
+  totalOriginalPrice: number;
+  totalDiscountedPrices: number;
+  totalCommonDeliveryFees: number;
+  totalSafetyDeliveryFees: number;
 }
 
 export interface CartStoreSectionData {
   storeName: string;
   items: CartItemData[];
-  checked: boolean;
+  checked?: boolean;
 }
 
 export interface CartStoreSection {
@@ -36,15 +42,7 @@ export interface CartStoreSection {
 }
 
 export interface CartList {
-  data: CartStoreSectionData[];
-  setData: React.Dispatch<SetStateAction<CartStoreSectionData[]>>;
-  checkedItemData: {
-    totalCount: number;
-    totalOriginalPrice: number;
-    totalDiscountedPrices: number;
-    totalCommonDeliveryFees: number;
-    totalSafetyDeliveryFees: number;
-  };
+  checkedItemData: CheckedItemData;
 }
 
 export interface CartItem {

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -4,164 +4,112 @@ import { BlueButton, TopNav } from '../components/molecules';
 import { theme } from '../styles/theme';
 import { useNavigate } from 'react-router-dom';
 import { CartList } from '../components/organisms';
-import { CartStoreSectionData } from '../interfaces/cart';
-import { useState } from 'react';
+import { CartItemData, CheckedItemData } from '../interfaces/cart';
+import { useQuery } from '@tanstack/react-query';
+import { getCartsAPI } from '../apis';
+import { useCartStore } from '../states';
+import { useEffect } from 'react';
 
 const CartPage = () => {
   const navigate = useNavigate();
-  const [data, setData] = useState<CartStoreSectionData[]>([
-    {
-      storeName: 'S아쿠아',
-      items: [
-        {
-          id: 1,
-          storeName: 'S아쿠아',
-          productId: 1,
-          productName: '알비노 풀레드 아시안 고정구피',
-          productThumbnailUrl:
-            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
-          productPrice: 30000,
-          productDiscountRate: 30,
-          productDiscountPrice: 21000,
-          quantity: 1,
-          sex: 'MALE',
-          deliveryMethod: 'COMMON',
-          deliveryFee: 3000,
-          isOnSale: true,
-          safeDeliveryFee: 5000,
-          commonDeliveryFee: 3000,
-          pickUpDeliveryFee: 0,
-          maleAdditionalPrice: 1000,
-          femaleAdditionalPrice: 1000,
-          checked: true,
-        },
-        {
-          id: 2,
-          storeName: 'S아쿠아',
-          productId: 2,
-          productName: '알비노 풀레드 아시안 고정구피',
-          productThumbnailUrl:
-            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
-          productPrice: 30000,
-          productDiscountRate: 30,
-          productDiscountPrice: 21000,
-          quantity: 1,
-          sex: 'MALE',
-          deliveryMethod: 'SAFETY',
-          deliveryFee: 5000,
-          isOnSale: true,
-          safeDeliveryFee: 5000,
-          commonDeliveryFee: 3000,
-          pickUpDeliveryFee: 0,
-          maleAdditionalPrice: 1000,
-          femaleAdditionalPrice: 1000,
-          checked: true,
-        },
-      ],
-      checked: true,
-    },
-    {
-      storeName: '현대올림피아드 아쿠아',
-      items: [
-        {
-          id: 3,
-          storeName: '현대올림피아드 아쿠아',
-          productId: 3,
-          productName: '알비노 풀레드 아시안 고정구피',
-          productThumbnailUrl:
-            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
-          productPrice: 30000,
-          productDiscountRate: 30,
-          productDiscountPrice: 21000,
-          quantity: 1,
-          sex: 'MALE',
-          deliveryMethod: 'COMMON',
-          deliveryFee: 3000,
-          isOnSale: true,
-          safeDeliveryFee: 5000,
-          commonDeliveryFee: 3000,
-          pickUpDeliveryFee: 0,
-          maleAdditionalPrice: 1000,
-          femaleAdditionalPrice: 1000,
-          checked: true,
-        },
-        {
-          id: 4,
-          storeName: '현대올림피아드 아쿠아',
-          productId: 4,
-          productName: '알비노 풀레드 아시안 고정구피',
-          productThumbnailUrl:
-            'https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg',
-          productPrice: 30000,
-          productDiscountRate: 30,
-          productDiscountPrice: 21000,
-          quantity: 1,
-          sex: 'MALE',
-          deliveryMethod: 'PICKUP',
-          deliveryFee: 0,
-          isOnSale: true,
-          safeDeliveryFee: 5000,
-          commonDeliveryFee: 3000,
-          pickUpDeliveryFee: 0,
-          maleAdditionalPrice: 1000,
-          femaleAdditionalPrice: 1000,
-          checked: true,
-        },
-      ],
-      checked: true,
-    },
-  ]);
+  const { items, setItems } = useCartStore();
 
-  const checkedItemData = data.reduce(
-    (total, store) => {
-      const checkedItems = store.items.filter((item) => item.checked);
-      // 선택된 상품의 원가
-      const originalPrices = checkedItems.reduce((totalPrice, item) => {
-        return totalPrice + item.productPrice;
-      }, 0);
+  const { data: cartData, status } = useQuery({
+    queryKey: ['cart'],
+    queryFn: getCartsAPI,
+    staleTime: 0,
+    select: (data) => {
+      const classifiedByStoreName = data
+        ?.map((item) => ({ ...item, checked: true }))
+        .reduce(
+          (acc, item) => {
+            // 현재 아이템의 storeName이 acc 객체에 키로 존재하지 않으면 새 배열을 생성
+            if (!acc[item.storeName]) {
+              acc[item.storeName] = [];
+            }
 
-      // 선택된 상품의 할인된 가격
-      const discountedPrices = checkedItems.reduce((totalPrice, item) => {
-        return totalPrice + item.productDiscountPrice;
-      }, 0);
+            // 현재 아이템을 해당 storeName의 배열에 추가
+            acc[item.storeName].push(item);
 
-      // 선택된 상품의 일반운송비
-      const commonDeliveryFees = checkedItems.reduce((totalFee, item) => {
-        if (item.deliveryMethod === 'COMMON') {
-          return totalFee + item.deliveryFee;
-        }
-        return totalFee;
-      }, 0);
-      // 선택된 상품의 안전운송비
-      const safetyDeliveryFees = checkedItems.reduce((totalFee, item) => {
-        if (item.deliveryMethod === 'SAFETY') {
-          return totalFee + item.deliveryFee;
-        }
-        return totalFee;
-      }, 0);
-      return {
-        totalCount: total.totalCount + checkedItems.length,
-        totalOriginalPrice: total.totalOriginalPrice + originalPrices,
-        totalDiscountedPrices: total.totalDiscountedPrices + discountedPrices,
-        totalCommonDeliveryFees:
-          total.totalCommonDeliveryFees + commonDeliveryFees,
-        totalSafetyDeliveryFees:
-          total.totalSafetyDeliveryFees + safetyDeliveryFees,
-      };
+            return acc;
+          },
+          {} as Record<string, CartItemData[]>,
+        );
+      const classifiedArray = Object.keys(classifiedByStoreName).map(
+        (storeName) => ({
+          storeName,
+          items: classifiedByStoreName[storeName],
+          checked: true,
+        }),
+      );
+      return classifiedArray;
     },
-    {
-      totalCount: 0,
-      totalOriginalPrice: 0,
-      totalDiscountedPrices: 0,
-      totalCommonDeliveryFees: 0,
-      totalSafetyDeliveryFees: 0,
-    },
-  );
+  });
+
+  useEffect(() => {
+    setItems(cartData || []);
+  }, [status]);
+
+  const checkedItemData = items
+    ? items.reduce(
+        (total, store) => {
+          const checkedItems = store.items.filter((item) => item.checked);
+          // 선택된 상품의 원가
+          const originalPrices = checkedItems.reduce((totalPrice, item) => {
+            return totalPrice + (item?.productPrice * item?.quantity || 0);
+          }, 0);
+
+          // 선택된 상품의 할인된 가격
+          const discountedPrices = checkedItems.reduce((totalPrice, item) => {
+            return (
+              totalPrice + (item?.productDiscountPrice * item?.quantity || 0)
+            );
+          }, 0);
+
+          // 선택된 상품의 일반운송비
+          const commonDeliveryFees = checkedItems.reduce((totalFee, item) => {
+            if (item.deliveryMethod === 'COMMON') {
+              return totalFee + item.deliveryFee;
+            }
+            return totalFee;
+          }, 0);
+          // 선택된 상품의 안전운송비
+          const safetyDeliveryFees = checkedItems.reduce((totalFee, item) => {
+            if (item.deliveryMethod === 'SAFETY') {
+              return totalFee + item.deliveryFee;
+            }
+            return totalFee;
+          }, 0);
+          return {
+            totalCount: total.totalCount + checkedItems.length,
+            totalOriginalPrice: total.totalOriginalPrice + originalPrices,
+            totalDiscountedPrices:
+              total.totalDiscountedPrices + discountedPrices,
+            totalCommonDeliveryFees:
+              total.totalCommonDeliveryFees + commonDeliveryFees,
+            totalSafetyDeliveryFees:
+              total.totalSafetyDeliveryFees + safetyDeliveryFees,
+          };
+        },
+        {
+          totalCount: 0,
+          totalOriginalPrice: 0,
+          totalDiscountedPrices: 0,
+          totalCommonDeliveryFees: 0,
+          totalSafetyDeliveryFees: 0,
+        },
+      )
+    : ({} as CheckedItemData);
+
+  const handlePay = () => {
+    console.log(items);
+    navigate('/payment');
+  };
 
   return (
     <>
       <TopNav title="봉달목록" backBtn wish />
-      {data.length === 0 ? (
+      {items?.length === 0 ? (
         <FlexBox
           col
           justify="center"
@@ -180,15 +128,11 @@ const CartPage = () => {
         </FlexBox>
       ) : (
         <>
-          <CartList
-            data={data}
-            setData={setData}
-            checkedItemData={checkedItemData}
-          />
+          <CartList checkedItemData={checkedItemData} />
           <PayButton>
             <BlueButton
-              text={`총 ${checkedItemData.totalCount}개 | ${(checkedItemData.totalDiscountedPrices + checkedItemData.totalCommonDeliveryFees + checkedItemData.totalSafetyDeliveryFees).toLocaleString()}원 결제하기`}
-              onClick={() => {}}
+              text={`총 ${checkedItemData?.totalCount}개 | ${(checkedItemData?.totalDiscountedPrices + checkedItemData?.totalCommonDeliveryFees + checkedItemData?.totalSafetyDeliveryFees)?.toLocaleString()}원 결제하기`}
+              onClick={handlePay}
             />
           </PayButton>
         </>

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -102,7 +102,6 @@ const CartPage = () => {
     : ({} as CheckedItemData);
 
   const handlePay = () => {
-    console.log(items);
     navigate('/payment');
   };
 

--- a/src/utils/delivery.ts
+++ b/src/utils/delivery.ts
@@ -7,7 +7,7 @@ export const getKoreanDeliveryMethod = (method: string) => {
       return '일반운송';
     case 'SAFETY':
       return '안전운송';
-    case 'PICKUP':
+    case 'PICK_UP':
       return '직접방문';
     default:
       return method;
@@ -33,7 +33,7 @@ export const getBackgroundColor = (method: string) => {
       return theme.color.blue[80];
     case 'COMMON':
       return theme.color.gray[40];
-    case 'PICKUP':
+    case 'PICK_UP':
       return theme.color.gray.main;
     default:
       return 'white';
@@ -43,7 +43,7 @@ export const getBackgroundColor = (method: string) => {
 export const getTextColor = (method: string) => {
   switch (method) {
     case 'SAFETY':
-    case 'PICKUP':
+    case 'PICK_UP':
       return theme.color.tint.white;
     case 'COMMON':
       return theme.color.gray.main;


### PR DESCRIPTION
> Close #103 

## 사진
### 봉달목록 리스트
![image](https://github.com/petqua/frontend/assets/123801984/174546d9-74b9-4c21-8b0c-dbb7abfd43b0)

### 
## 커밋 리스트

#### ✅ feat: 봉달목록 옵션 수정 api 연동

#### ✅ feat: 봉달목록 상품 삭제 api 연동

#### ✅ feat: 봉달목록 조회 api 연동

- 수량 반영한 가격으로 표시 변경

#### ✅ feat: 결제페이지 이동기능

- 전역상태로 봉달목록 리스트 관리

#### ✅ refactor: 리뷰 요청사항 반영

- console.log 제거

## Comment

- 결제페이지로 들어가는 주소를 정확하게 모르겠어서 '/payment'라고 작성했는데 이거 추후에 지호님이 결제페이지 작업 다하시고 수정해주세요!
