### PR TITLE
[#131] 아이콘 라이브러리 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fe",
       "version": "0.0.0",
       "dependencies": {
+        "@react-icons/all-files": "^4.1.0",
         "@tanstack/react-query": "^5.17.19",
         "@tanstack/react-query-devtools": "^5.17.21",
         "@tosspayments/payment-widget-sdk": "^0.10.2",
@@ -1163,6 +1164,14 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@react-icons/all-files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/@remix-run/router": {
@@ -3745,9 +3754,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -7499,6 +7508,12 @@
       "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
       "dev": true
     },
+    "@react-icons/all-files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
+      "requires": {}
+    },
     "@remix-run/router": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.0.tgz",
@@ -9211,9 +9226,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-icons/all-files": "^4.1.0",
     "@tanstack/react-query": "^5.17.19",
     "@tanstack/react-query-devtools": "^5.17.21",
     "@tosspayments/payment-widget-sdk": "^0.10.2",

--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 import { theme } from '../../styles/theme';
-import { FaCheck } from 'react-icons/fa6';
+import { FaCheck } from './Icon';
 
 interface CheckBox {
   checked: boolean | undefined;

--- a/src/components/atoms/Icon.tsx
+++ b/src/components/atoms/Icon.tsx
@@ -1,0 +1,59 @@
+import { AiOutlineCloseSquare } from '@react-icons/all-files/ai/AiOutlineCloseSquare';
+import { AiOutlineCloseCircle } from '@react-icons/all-files/ai/AiOutlineCloseCircle';
+import { BsPerson } from '@react-icons/all-files/bs/BsPerson';
+import { FaAngleDown } from '@react-icons/all-files/fa/FaAngleDown';
+import { FaCheck } from '@react-icons/all-files/fa/FaCheck';
+import { FaChevronRight } from '@react-icons/all-files/fa/FaChevronRight';
+import { FaRegThumbsUp } from '@react-icons/all-files/fa/FaRegThumbsUp';
+import { FaThumbsUp } from '@react-icons/all-files/fa/FaThumbsUp';
+import { FaStar } from '@react-icons/all-files/fa/FaStar';
+import { FaStarHalf } from '@react-icons/all-files/fa/FaStarHalf';
+import { FaMinus } from '@react-icons/all-files/fa/FaMinus';
+import { FaPlus } from '@react-icons/all-files/fa/FaPlus';
+import { GrNext } from '@react-icons/all-files/gr/GrNext';
+import { GrPrevious } from '@react-icons/all-files/gr/GrPrevious';
+import { IoHomeOutline } from '@react-icons/all-files/io5/IoHomeOutline';
+import { IoSearchOutline } from '@react-icons/all-files/io5/IoSearchOutline';
+import { IoIosArrowBack } from '@react-icons/all-files/io/IoIosArrowBack';
+import { IoIosArrowUp } from '@react-icons/all-files/io/IoIosArrowUp';
+import { IoIosArrowDown } from '@react-icons/all-files/io/IoIosArrowDown';
+import { IoIosCheckmark } from '@react-icons/all-files/io/IoIosCheckmark';
+import { IoOptionsOutline } from '@react-icons/all-files/io5/IoOptionsOutline';
+import { IoChevronBackOutline } from '@react-icons/all-files/io5/IoChevronBackOutline';
+import { IoClose } from '@react-icons/all-files/io5/IoClose';
+import { IoCloseOutline } from '@react-icons/all-files/io5/IoCloseOutline';
+import { IoChevronDownCircleSharp } from '@react-icons/all-files/io5/IoChevronDownCircleSharp';
+import { IoChevronUpCircleSharp } from '@react-icons/all-files/io5/IoChevronUpCircleSharp';
+import { IoShareSocialOutline } from '@react-icons/all-files/io5/IoShareSocialOutline';
+import { TiDelete } from '@react-icons/all-files/ti/TiDelete';
+
+export {
+  FaCheck,
+  IoHomeOutline,
+  IoSearchOutline,
+  BsPerson,
+  GrNext,
+  GrPrevious,
+  AiOutlineCloseSquare,
+  IoIosArrowUp,
+  IoIosArrowDown,
+  IoIosCheckmark,
+  FaAngleDown,
+  IoOptionsOutline,
+  FaChevronRight,
+  IoChevronBackOutline,
+  IoClose,
+  IoChevronDownCircleSharp,
+  IoChevronUpCircleSharp,
+  AiOutlineCloseCircle,
+  FaRegThumbsUp,
+  FaThumbsUp,
+  TiDelete,
+  IoIosArrowBack,
+  FaStar,
+  FaStarHalf,
+  IoCloseOutline,
+  IoShareSocialOutline,
+  FaMinus,
+  FaPlus,
+};

--- a/src/components/molecules/BottomNavBar.tsx
+++ b/src/components/molecules/BottomNavBar.tsx
@@ -1,12 +1,11 @@
 import styled from 'styled-components';
-import { GoHomeFill } from 'react-icons/go';
-import { CiSearch } from 'react-icons/ci';
-import { BsPerson } from 'react-icons/bs';
+
 import ChatIcon from '../../assets/chat.svg?react';
 import DoubleFish from '../../assets/double-fish.svg?react';
 import { RegularText } from '../atoms';
 import { theme } from '../../styles/theme';
 import { useNavigate } from 'react-router-dom';
+import { BsPerson, IoSearchOutline, IoHomeOutline } from '../atoms/Icon';
 
 const Footer = styled.footer`
   position: fixed;
@@ -41,10 +40,10 @@ const BottomNavBar = ({ activeButton }: BottomNavBar) => {
   const navigate = useNavigate();
   return (
     <Footer>
-      <NavButton>
-        <GoHomeFill
+      <NavButton onClick={() => navigate('/')}>
+        <IoHomeOutline
           size={26}
-          fill={activeButton === 'home' ? theme.color.blue[70] : undefined}
+          color={activeButton === 'home' ? theme.color.blue[70] : undefined}
         />
         <RegularText
           size={10}
@@ -57,10 +56,10 @@ const BottomNavBar = ({ activeButton }: BottomNavBar) => {
           홈
         </RegularText>
       </NavButton>
-      <NavButton>
-        <CiSearch
+      <NavButton onClick={() => navigate('/search')}>
+        <IoSearchOutline
           size={26}
-          fill={activeButton === 'search' ? theme.color.blue[70] : undefined}
+          color={activeButton === 'search' ? theme.color.blue[70] : undefined}
         />
         <RegularText
           size={10}
@@ -107,10 +106,10 @@ const BottomNavBar = ({ activeButton }: BottomNavBar) => {
           물생활
         </RegularText>
       </NavButton>
-      <NavButton onClick={() => navigate('/login')}>
+      <NavButton onClick={() => navigate('/myPage')}>
         <BsPerson
           size={26}
-          fill={activeButton === 'profile' ? theme.color.blue[70] : undefined}
+          color={activeButton === 'profile' ? theme.color.blue[70] : undefined}
         />
         <RegularText
           size={10}

--- a/src/components/molecules/Carousel.tsx
+++ b/src/components/molecules/Carousel.tsx
@@ -3,8 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import { ImageDetail } from '../organisms';
 import { RegularText } from '../atoms';
 import { theme } from '../../styles/theme';
-import { GrNext, GrPrevious } from 'react-icons/gr';
 import { Carousel } from '../../interfaces/carousel';
+import { GrNext, GrPrevious } from '../atoms/Icon';
 
 const Carousel = ({
   carouselList,

--- a/src/components/molecules/CartItem.tsx
+++ b/src/components/molecules/CartItem.tsx
@@ -10,7 +10,6 @@ import {
 } from '../atoms';
 import { OptionModal } from '../organisms';
 import Confirm from './Confirm';
-import { LiaWindowClose } from 'react-icons/lia';
 import { CartItem } from '../../interfaces/cart';
 import {
   getKoreanDeliveryMethod,
@@ -21,6 +20,7 @@ import {
 import { deleteCartsAPI } from '../../apis';
 import { useMutation } from '@tanstack/react-query';
 import { useCartStore } from '../../states';
+import { AiOutlineCloseSquare } from '../atoms/Icon';
 
 const CartItem = ({ data, handleSelectItem }: CartItem) => {
   const [isOpenModal, setIsOpenModal] = useState(false);
@@ -91,7 +91,7 @@ const CartItem = ({ data, handleSelectItem }: CartItem) => {
                     </MethodTag>
                   </MediumText>
                 </FlexBox>
-                <LiaWindowClose
+                <AiOutlineCloseSquare
                   size={18}
                   color={theme.color.gray[50]}
                   style={{ cursor: 'pointer' }}

--- a/src/components/molecules/DeliveryRequestDropdown.tsx
+++ b/src/components/molecules/DeliveryRequestDropdown.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { RegularText } from '../atoms';
 import { theme } from '../../styles/theme';
-import { IoIosArrowUp, IoIosArrowDown, IoIosCheckmark } from 'react-icons/io';
+import { IoIosArrowDown, IoIosArrowUp, IoIosCheckmark } from '../atoms/Icon';
 import { usePaymentStore } from '../../states';
 
 const Container = styled.section`

--- a/src/components/molecules/Filter.tsx
+++ b/src/components/molecules/Filter.tsx
@@ -1,10 +1,11 @@
 import { SetStateAction } from 'react';
-import { FaAngleDown } from 'react-icons/fa6';
+
 import { theme } from '../../styles/theme';
 import styled from 'styled-components';
 import { MediumText } from '../atoms';
 import { formatFilter } from '../../utils/format';
-import { IoOptionsOutline } from 'react-icons/io5';
+import { FaAngleDown, IoOptionsOutline } from '../atoms/Icon';
+
 
 interface Filter {
   title: string;

--- a/src/components/molecules/Modal.tsx
+++ b/src/components/molecules/Modal.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 import { BoldText, FlexBox } from '../atoms';
 import { theme } from '../../styles/theme';
 import styled from 'styled-components';
-import { IoChevronBackOutline, IoClose } from 'react-icons/io5';
 import { fadeIn, fadeOut, slideUp, slideDown } from '../../styles/keyframes';
+import { IoChevronBackOutline, IoClose } from '../atoms/Icon';
 
 interface Modal {
   children: React.ReactNode;

--- a/src/components/molecules/PaymentSummary.tsx
+++ b/src/components/molecules/PaymentSummary.tsx
@@ -3,11 +3,12 @@ import { theme } from '../../styles/theme';
 import { BoldText, CustomHr, FlexBox, RegularText } from '../atoms';
 import { TotalFee } from '../../interfaces/payment';
 import { getTotalDeliveryFee } from '../../utils/delivery';
+
+import { memo, useState } from 'react';
 import {
   IoChevronDownCircleSharp,
   IoChevronUpCircleSharp,
-} from 'react-icons/io5';
-import { memo, useState } from 'react';
+} from '../atoms/Icon';
 
 const Container = styled.section`
   padding: 2.4rem 1.4rem;

--- a/src/components/molecules/RecentSearchList.tsx
+++ b/src/components/molecules/RecentSearchList.tsx
@@ -2,8 +2,8 @@ import { styled } from 'styled-components';
 import { useSearchStore } from '../../states';
 import { BoldText, FlexBox, MediumText, RegularText } from '../atoms';
 import { theme } from '../../styles/theme';
-import { AiOutlineCloseCircle } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
+import { AiOutlineCloseCircle } from '../atoms/Icon';
 
 const Container = styled.div`
   width: 100%;

--- a/src/components/molecules/ReviewItem.tsx
+++ b/src/components/molecules/ReviewItem.tsx
@@ -8,12 +8,12 @@ import {
   ProfileImg,
   RegularText,
 } from '../atoms';
-import { FaRegThumbsUp, FaThumbsUp } from 'react-icons/fa6';
 import { ReviewItem } from '../../interfaces/review';
 import { formatDate } from '../../utils/format';
 import { useMutation } from '@tanstack/react-query';
 import { postReviewRecommendAPI } from '../../apis';
 import { useState } from 'react';
+import { FaRegThumbsUp, FaThumbsUp } from '../atoms/Icon';
 
 const ReviewItem = ({ data, isRecommend, isLastItem }: ReviewItem) => {
   const [showRecommended, setShowRecommended] = useState(data?.recommended);

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -1,10 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { useSearchStore } from '../../states';
-import { IoIosArrowBack } from 'react-icons/io';
-import { CiSearch } from 'react-icons/ci';
-import { TiDelete } from 'react-icons/ti';
 import { theme } from '../../styles/theme';
+import { IoIosArrowBack, IoSearchOutline, TiDelete } from '../atoms/Icon';
 
 const TopBar = styled.header`
   display: flex;
@@ -87,7 +85,7 @@ const SearchBar = () => {
           </button>
         ) : (
           <button>
-            <CiSearch size={22} />
+            <IoSearchOutline size={22} />
           </button>
         )}
       </InputDiv>

--- a/src/components/molecules/StarRating.tsx
+++ b/src/components/molecules/StarRating.tsx
@@ -1,6 +1,6 @@
 import { theme } from '../../styles/theme';
 import { FlexBox } from '../atoms';
-import { FaStar, FaStarHalf } from 'react-icons/fa';
+import { FaStar, FaStarHalf } from '../atoms/Icon';
 
 interface StarRating {
   score: number;

--- a/src/components/molecules/TopNav.tsx
+++ b/src/components/molecules/TopNav.tsx
@@ -1,9 +1,8 @@
 import { FlexBox, MediumText, RegularText } from '../atoms';
 import { theme } from '../../styles/theme';
-import { CiSearch } from 'react-icons/ci';
-import { GoChevronLeft } from 'react-icons/go';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
+import { IoIosArrowBack, IoSearchOutline } from '../atoms/Icon';
 
 interface TopNav {
   backBtn?: boolean;
@@ -40,7 +39,7 @@ const TopNav = ({
           style={{ width: searchBar ? '' : '6rem' }}
         >
           {backBtn && (
-            <GoChevronLeft
+            <IoIosArrowBack
               size={24}
               color={theme.color.gray.main}
               onClick={() => (backToHome ? navigate('/') : navigate(-1))}
@@ -62,7 +61,7 @@ const TopNav = ({
             <RegularText size={12} color={theme.color.gray.main}>
               검색어를 입력해주세요
             </RegularText>
-            <CiSearch size={20} color={theme.color.gray.main} />
+            <IoSearchOutline size={20} color={theme.color.gray.main} />
           </SearchBar>
         )}
         {title && (
@@ -80,7 +79,9 @@ const TopNav = ({
           gap="1.6rem"
           style={{ width: '6rem' }}
         >
-          {search && <CiSearch size={24} onClick={() => navigate('/search')} />}
+          {search && (
+            <IoSearchOutline size={24} onClick={() => navigate('/search')} />
+          )}
           {wish && (
             <img
               src="/icons/bubble-like-gray.svg"

--- a/src/components/molecules/TrendingKeywordList.tsx
+++ b/src/components/molecules/TrendingKeywordList.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
-import { CiSearch } from 'react-icons/ci';
 import { KeywordText } from '../atoms';
 import { useSearchStore } from '../../states';
 import { useNavigate } from 'react-router-dom';
+import { IoSearchOutline } from '../atoms/Icon';
 
 interface TrendingKeyword {
   id: number;
@@ -66,7 +66,7 @@ const TrendingKeywordList = ({ data, debouncedQuery }: TrendingKeywordList) => {
               handleClick(item.keyword);
             }}
           >
-            <CiSearch size={22} />
+            <IoSearchOutline size={22} />
             <KeywordText keyword={item.keyword} query={debouncedQuery} />
           </RecommendLi>
         ))}

--- a/src/components/molecules/WhiteButton.tsx
+++ b/src/components/molecules/WhiteButton.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 import { theme } from '../../styles/theme';
 import { MediumText } from '../atoms';
-import { FaChevronDown } from 'react-icons/fa6';
+import { IoIosArrowDown } from '../atoms/Icon';
 
 interface WhiteButton {
   text: string;
@@ -31,7 +31,7 @@ const WhiteButton = ({
         {text}
       </MediumText>
       {/* 사용되는 다른 상황에 따라 유연하게 수정 */}
-      {isDown && <FaChevronDown size={12} color={theme.color.blue[70]} />}
+      {isDown && <IoIosArrowDown size={20} color={theme.color.blue[70]} />}
     </Button>
   );
 };

--- a/src/components/organisms/CartList.tsx
+++ b/src/components/organisms/CartList.tsx
@@ -2,10 +2,10 @@ import { styled } from 'styled-components';
 import { theme } from '../../styles/theme';
 import { BoldText, MediumText, FlexBox, RegularText, CheckBox } from '../atoms';
 import { useState } from 'react';
-import { IoIosArrowDown } from 'react-icons/io';
 import { CartList } from '../../interfaces/cart';
 import { CartStoreSection } from '../molecules';
 import { useCartStore } from '../../states';
+import { IoIosArrowDown } from '../atoms/Icon';
 
 const CartList = ({ checkedItemData }: CartList) => {
   const { items, setItems } = useCartStore();

--- a/src/components/organisms/ImageDetail.tsx
+++ b/src/components/organisms/ImageDetail.tsx
@@ -3,8 +3,8 @@ import { styled } from 'styled-components';
 import { fadeIn, fadeOut } from '../../styles/keyframes';
 import { theme } from '../../styles/theme';
 import { Carousel } from '../molecules';
-import { IoCloseOutline } from 'react-icons/io5';
 import { ImageDetail } from '../../interfaces/carousel';
+import { IoCloseOutline } from '../atoms/Icon';
 
 const ImageDetail = ({ setIsOpenDetail, idx, carouselList }: ImageDetail) => {
   const [visible, setVisible] = useState(true);

--- a/src/components/organisms/ProductDetailMain.tsx
+++ b/src/components/organisms/ProductDetailMain.tsx
@@ -1,9 +1,9 @@
 import { theme } from '../../styles/theme';
 import { FlexBox, BoldText, RegularText } from '../atoms';
-import { IoShareSocialOutline } from 'react-icons/io5';
 import { styled } from 'styled-components';
 import { ProductDetailMain } from '../../interfaces/product';
 import { StarRating } from '../molecules';
+import { IoShareSocialOutline } from '../atoms/Icon';
 
 const ProductDetailMain = ({
   data,

--- a/src/components/organisms/ReviewList.tsx
+++ b/src/components/organisms/ReviewList.tsx
@@ -7,7 +7,7 @@ import InfiniteScroll from 'react-infinite-scroller';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getReviewsAPI } from '../../apis';
 import { useParams } from 'react-router-dom';
-import { FaCheck } from 'react-icons/fa6';
+import { FaCheck } from '../atoms/Icon';
 
 interface ReviewList {
   score: number | null;

--- a/src/components/organisms/modals/ListModal.tsx
+++ b/src/components/organisms/modals/ListModal.tsx
@@ -1,10 +1,10 @@
 import { SetStateAction, useState } from 'react';
 import { RegularText, BoldText, FlexBox } from '../../atoms';
 import { theme } from '../../../styles/theme';
-import { FaCheck } from 'react-icons/fa6';
 import Modal from '../../molecules/Modal';
 import { formatFilter } from '../../../utils/format';
 import { useSearchParams } from 'react-router-dom';
+import { FaCheck } from '../../atoms/Icon';
 
 interface ListModal {
   value: string | null;

--- a/src/components/organisms/modals/OptionModal.tsx
+++ b/src/components/organisms/modals/OptionModal.tsx
@@ -4,11 +4,12 @@ import { theme } from '../../../styles/theme';
 import { BlueButton, WhiteButton } from '../../molecules';
 import Modal from '../../molecules/Modal';
 import styled from 'styled-components';
-import { FaMinus, FaPlus } from 'react-icons/fa6';
 import { useMutation } from '@tanstack/react-query';
 import { patchCartsOptionsAPI, postCartsAPI } from '../../../apis';
 import { usePopUpStore, useCartStore } from '../../../states';
 import { OptionModalData } from '../../../interfaces/product';
+import { FaMinus, FaPlus } from '../../atoms/Icon';
+// import { useNavigate } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 
 interface OptionModal {
@@ -206,7 +207,7 @@ const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
               }}
             >
               <FaMinus
-                size={16}
+                size={12}
                 color={theme.color.gray[50]}
                 style={{ cursor: 'pointer' }}
                 onClick={() => handleQuantity(-1)}
@@ -215,7 +216,7 @@ const OptionModal = ({ setIsOpenModal, data, isEdit }: OptionModal) => {
                 {requestData.quantity}
               </RegularText>
               <FaPlus
-                size={16}
+                size={12}
                 color={theme.color.gray[50]}
                 style={{ cursor: 'pointer' }}
                 onClick={() => handleQuantity(1)}

--- a/src/components/organisms/modals/SpeciesModal.tsx
+++ b/src/components/organisms/modals/SpeciesModal.tsx
@@ -1,12 +1,11 @@
 import { SetStateAction, useState } from 'react';
 import { RegularText, FlexBox } from '../../atoms';
 import { theme } from '../../../styles/theme';
-import { FaCheck } from 'react-icons/fa6';
-import { GoPlus } from 'react-icons/go';
 import Modal from '../../molecules/Modal';
 import styled from 'styled-components';
 import { useSearchParams } from 'react-router-dom';
 import { BlueButton } from '../../molecules';
+import { FaCheck, FaPlus } from '../../atoms/Icon';
 
 interface SpeciesModal {
   value: string[];
@@ -66,7 +65,7 @@ const SpeciesModal = ({ setIsOpenModal, value, options }: SpeciesModal) => {
                 {isSelected ? (
                   <FaCheck size={16} color={theme.color.gray.main} />
                 ) : (
-                  <GoPlus size={20} color={theme.color.gray[60]} />
+                  <FaPlus size={20} color={theme.color.gray[60]} />
                 )}
               </FlexBox>
             );

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -25,9 +25,9 @@ import {
   getReviewStatisticsAPI,
   getCategoryProductsAPI,
 } from '../apis';
-import { FaChevronRight } from 'react-icons/fa6';
 import { useState } from 'react';
 import { OptionModalData } from '../interfaces/product';
+import { FaChevronRight } from '../components/atoms/Icon';
 
 const ProductDetailPage = () => {
   const { productId } = useParams();


### PR DESCRIPTION
> Close #131 

## 변경 사항
### 변경 전
![image](https://github.com/petqua/frontend/assets/123801984/300fd789-d8f1-4bf4-8675-646c70c817f6)

### 변경 후
![image](https://github.com/petqua/frontend/assets/123801984/bb514d2b-f3a7-4b52-b476-84ff479e4390)

### 최적화 내용
- Resource: 18.5MB -> 8.2MB **(55.6% 감소)**
- Loading Time: 1.46s -> 731ms **(50% 감소)**

### 변경 후 단점 
- react-icons/all-files가 업데이트한지 오래돼서 기존 react-icons에 있는 모든 아이콘이 없다는 단점이 있습니다ㅠㅠ
- 최대한 비슷한 아이콘으로 대체하긴 했으나 마땅한 아이콘이 없는 경우 svg파일로 추출하여 사용해야할 것 같습니다.
- 단점은 존재하나 통신의 최적화 내용을 보면 충분히 변경할 가치가 있다고 생각해서 리팩토링 진행하였습니다!

## 커밋 리스트

#### ✅ refactor: 아이콘 라이브러리 변경

- react-icons -> react-icons/all-files

